### PR TITLE
Take locale into account when ordering apps and ignore diacritics during search

### DIFF
--- a/app/src/main/java/app/olauncher/data/AppModel.kt
+++ b/app/src/main/java/app/olauncher/data/AppModel.kt
@@ -1,9 +1,16 @@
 package app.olauncher.data
 
 import android.os.UserHandle
+import java.text.CollationKey
 
 data class AppModel(
-    val appLabel: String,
-    val appPackage: String,
-    val user: UserHandle
-)
+        val appLabel: String,
+        val key: CollationKey?,
+        val appPackage: String,
+        val user: UserHandle
+) : Comparable<AppModel> {
+    override fun compareTo(other: AppModel): Int = when {
+        key != null && other.key != null -> key.compareTo(other.key)
+        else -> appLabel.compareTo(other.appLabel, true)
+    }
+}

--- a/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
@@ -11,6 +11,7 @@ import app.olauncher.R
 import app.olauncher.data.AppModel
 import app.olauncher.data.Constants
 import kotlinx.android.synthetic.main.adapter_app_drawer.view.*
+import java.text.Normalizer
 
 class AppDrawerAdapter(
     private var flag: Int,
@@ -73,7 +74,9 @@ class AppDrawerAdapter(
 
     private fun appLabelMatches(appLabel: String, searchChars: String): Boolean {
         return (appLabel.contains(searchChars, true) or
-                appLabel.replace(Regex("[-_+,. ]"), "")
+                Normalizer.normalize(appLabel, Normalizer.Form.NFD)
+                        .replace(Regex("\\p{InCombiningDiacriticalMarks}+"), "")
+                        .replace(Regex("[-_+,. ]"), "")
                     .contains(searchChars, true))
     }
 

--- a/app/src/main/java/app/olauncher/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/HomeFragment.kt
@@ -248,7 +248,7 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
 
     private fun launchApp(appName: String, packageName: String, userString: String) {
         viewModel.selectedApp(
-            AppModel(appName, packageName, getUserHandleFromString(requireContext(), userString)),
+            AppModel(appName, null, packageName, getUserHandleFromString(requireContext(), userString)),
             Constants.FLAG_LAUNCH_APP
         )
     }


### PR DESCRIPTION
This PR slightly changes the way the app drawer sorts apps, taking into account the current locale. It also ignore diacritics when searching to help find apps faster.