### PR TITLE
Fix renaming app issues

### DIFF
--- a/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
@@ -4,6 +4,7 @@ import android.os.UserHandle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.Filter
 import android.widget.Filterable
 import androidx.core.view.isVisible
@@ -14,6 +15,7 @@ import app.olauncher.R
 import app.olauncher.data.AppModel
 import app.olauncher.data.Constants
 import app.olauncher.databinding.AdapterAppDrawerBinding
+import app.olauncher.helper.hideKeyboard
 import app.olauncher.helper.isSystemApp
 import app.olauncher.helper.showKeyboard
 import java.text.Normalizer
@@ -171,12 +173,25 @@ class AppDrawerAdapter(
                         renameLayout.visibility = View.VISIBLE
                         appHideLayout.visibility = View.GONE
                         etAppRename.showKeyboard()
+                        etAppRename.imeOptions = EditorInfo.IME_ACTION_DONE;
                     }
                 }
+                etAppRename.setOnEditorActionListener { _, actionCode, _ ->
+                    if(actionCode == EditorInfo.IME_ACTION_DONE) {
+                        val renameLabel = etAppRename.text.toString().trim()
+                        if (renameLabel.isNotBlank() && appModel.appPackage.isNotBlank()) {
+                            appRenameListener(appModel, renameLabel)
+                        }
+                        true
+                    }
+                    false
+                }
                 tvSaveRename.setOnClickListener {
+                    etAppRename.hideKeyboard()
                     val renameLabel = etAppRename.text.toString().trim()
-                    if (renameLabel.isNotBlank() && appModel.appPackage.isNotBlank())
+                    if (renameLabel.isNotBlank() && appModel.appPackage.isNotBlank()) {
                         appRenameListener(appModel, renameLabel)
+                    }
                 }
                 appInfo.setOnClickListener { appInfoListener(appModel) }
                 appDelete.setOnClickListener { appDeleteListener(appModel) }

--- a/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
@@ -181,6 +181,7 @@ class AppDrawerAdapter(
                         val renameLabel = etAppRename.text.toString().trim()
                         if (renameLabel.isNotBlank() && appModel.appPackage.isNotBlank()) {
                             appRenameListener(appModel, renameLabel)
+                            renameLayout.visibility = View.GONE
                         }
                         true
                     }
@@ -191,6 +192,7 @@ class AppDrawerAdapter(
                     val renameLabel = etAppRename.text.toString().trim()
                     if (renameLabel.isNotBlank() && appModel.appPackage.isNotBlank()) {
                         appRenameListener(appModel, renameLabel)
+                        renameLayout.visibility = View.GONE
                     }
                 }
                 appInfo.setOnClickListener { appInfoListener(appModel) }


### PR DESCRIPTION
There is two renaming issue:
1) On keyboard action view tries next focus and crashes.
2) If name is same renaming won't stop.

This pull request fixes: #378 