### PR TITLE
Race condition between filtering and refreshing apps #417 

### DIFF
--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -75,9 +75,7 @@ class AppDrawerFragment : Fragment() {
         binding.search.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 if (query?.startsWith("!") == true)
-                    requireContext().openUrl(Constants.URL_DUCK_SEARCH + query
-                        .removePrefix("!")
-                        .replace(" ", "%20"))
+                    requireContext().openUrl(Constants.URL_DUCK_SEARCH + query.replace(" ", "%20"))
                 else if (adapter.itemCount == 0 && requireContext().searchOnPlayStore(query?.trim()).not())
                     requireContext().openSearch(query?.trim())
                 else

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -175,7 +175,10 @@ class AppDrawerFragment : Fragment() {
             }
         else
             viewModel.appList.observe(viewLifecycleOwner) {
-                it?.let { adapter.setAppList(it.toMutableList()) }
+                it?.let {
+                    adapter.setAppList(it.toMutableList())
+                    adapter.filter.filter(binding.search.query)
+                }
             }
     }
 

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -75,7 +75,9 @@ class AppDrawerFragment : Fragment() {
         binding.search.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 if (query?.startsWith("!") == true)
-                    requireContext().openUrl(Constants.URL_DUCK_SEARCH + query.replace(" ", "%20"))
+                    requireContext().openUrl(Constants.URL_DUCK_SEARCH + query
+                        .removePrefix("!")
+                        .replace(" ", "%20"))
                 else if (adapter.itemCount == 0 && requireContext().searchOnPlayStore(query?.trim()).not())
                     requireContext().openSearch(query?.trim())
                 else


### PR DESCRIPTION
Added updating filter on appList observer.
To test the change I added the following at line 79
```
   else if (query?.contains("o") == true) {
                    // Force an update to the appList
                    viewModel.appList.value = viewModel.appList.value
                }
```
Then I would enter into the search bar `pho` - Which should show the two options `photo` and `phone`

Then on submit we then get a forced update to appList (and skips opening an app)
- Without this PR -> The list gets filled with all the apps.
- With this PR      -> The list stays with just the two options

I haven't worked on android before so I hope this is good.

