### PR TITLE
Fix: Crash when search has no result

### DIFF
--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -388,6 +388,8 @@ class AppDrawerFragment : Fragment() {
 
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
+                if (linearLayoutManager.itemCount == 0)
+                    return
                 val visiblePosition = linearLayoutManager.findFirstVisibleItemPosition()
                 val position = if (visiblePosition >= 0) visiblePosition else 0
                 val item = adapter.currentList[position]


### PR DESCRIPTION
This PR solves the problem described in the following.

# Current behavior
The launcher crashes with the following exception when a search yields no results.
<details>
<summary>Exception</summary>
<pre>
FATAL EXCEPTION: main
Process: app.olauncher.debug, PID: 21124
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
    at java.util.ArrayList.get(ArrayList.java:437)
    at java.util.Collections$UnmodifiableList.get(Collections.java:1356)
    at app.olauncher.ui.AppDrawerFragment$getRecyclerViewOnScrollListener$1.onScrolled(AppDrawerFragment.kt:357)
    at androidx.recyclerview.widget.RecyclerView.dispatchOnScrolled(RecyclerView.java:5642)
    at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep3(RecyclerView.java:4700)
    at androidx.recyclerview.widget.RecyclerView.dispatchLayout(RecyclerView.java:4326)
    at androidx.recyclerview.widget.RecyclerView.onLayout(RecyclerView.java:4873)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
    at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1673)
    at android.widget.LinearLayout.onLayout(LinearLayout.java:1582)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
    at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1673)
    at android.widget.LinearLayout.onLayout(LinearLayout.java:1582)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
    at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
    at com.android.internal.policy.DecorView.onLayout(DecorView.java:797)
    at android.view.View.layout(View.java:23203)
    at android.view.ViewGroup.layout(ViewGroup.java:6412)
    at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:3755)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3205)
    at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2179)
    at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8793)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1037)
    at android.view.Choreographer.doCallbacks(Choreographer.java:845)
    at android.view.Choreographer.doFrame(Choreographer.java:780)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1022)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7870)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
</pre>
</details>

# How to reproduce
A simple way to create a search that does not have any results is to search for a character that is not part of any application name. For example the number `2` is probably not part of any application name.