### PR TITLE
Rename multiple activities from one app separately

### DIFF
--- a/app/src/main/java/app/olauncher/data/Prefs.kt
+++ b/app/src/main/java/app/olauncher/data/Prefs.kt
@@ -445,7 +445,7 @@ class Prefs(context: Context) {
         }
     }
 
-    fun getAppRenameLabel(appPackage: String): String = prefs.getString(appPackage, "").toString()
+    fun getAppRenameLabel(componentName: String?): String = prefs.getString(componentName, "").toString()
 
-    fun setAppRenameLabel(appPackage: String, renameLabel: String) = prefs.edit().putString(appPackage, renameLabel).apply()
+    fun setAppRenameLabel(componentName: String?, renameLabel: String) = prefs.edit().putString(componentName, renameLabel).apply()
 }

--- a/app/src/main/java/app/olauncher/helper/Utils.kt
+++ b/app/src/main/java/app/olauncher/helper/Utils.kt
@@ -83,7 +83,7 @@ suspend fun getAppsList(
             for (profile in userManager.userProfiles) {
                 for (app in launcherApps.getActivityList(null, profile)) {
 
-                    val appLabelShown = prefs.getAppRenameLabel(app.applicationInfo.packageName).ifBlank { app.label.toString() }
+                    val appLabelShown = prefs.getAppRenameLabel(app.componentName.className).ifBlank { app.label.toString() }
                     val appModel = AppModel(
                         appLabelShown,
                         collator.getCollationKey(app.label.toString()),

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -159,7 +159,7 @@ class AppDrawerFragment : Fragment() {
                 viewModel.getHiddenApps()
             },
             appRenameListener = { appModel, renameLabel ->
-                prefs.setAppRenameLabel(appModel.appPackage, renameLabel)
+                prefs.setAppRenameLabel(appModel.activityClassName, renameLabel)
                 viewModel.getAppList()
             }
         )


### PR DESCRIPTION
This pull request partly implements #415 by storing rename labels by component name instead of package name, which allows different activities to be renamed separately.

There is still no option to reset renames, so it isn't completely done. (I will however try to implement that soon as well.)

Please also add the `hacktoberfest-accepted` label to this pull request as it was made for Hacktoberfest 2024. Thank you for your awesome launcher!