### PR TITLE
Fixes issue #434: App sort places ç after z

### DIFF
--- a/app/src/main/java/app/olauncher/helper/Utils.kt
+++ b/app/src/main/java/app/olauncher/helper/Utils.kt
@@ -84,9 +84,10 @@ suspend fun getAppsList(
                 for (app in launcherApps.getActivityList(null, profile)) {
 
                     val appLabelShown = prefs.getAppRenameLabel(app.applicationInfo.packageName).ifBlank { app.label.toString() }
+                    val appLabelCollationKey = collator.getCollationKey(app.label.toString().lowercase())
                     val appModel = AppModel(
                         appLabelShown,
-                        collator.getCollationKey(app.label.toString()),
+                        appLabelCollationKey,
                         app.applicationInfo.packageName,
                         app.componentName.className,
                         (System.currentTimeMillis() - app.firstInstallTime) < Constants.ONE_HOUR_IN_MILLIS,
@@ -109,7 +110,7 @@ suspend fun getAppsList(
                     }
                 }
             }
-            appList.sortBy { it.appLabel.lowercase() }
+            appList.sort()
 
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Diacritical characters are now taken into account when sorting apps names

| Before | After |
| ------ | ------ |
| <img width="200" alt="Screenshot 2025-03-12 at 23 25 01" src="https://github.com/user-attachments/assets/84e61470-2ec3-4b27-b676-6fe3a3e50f72" />  |  <img width="200" alt="Screenshot 2025-03-12 at 23 35 50" src="https://github.com/user-attachments/assets/9914ec9f-d11b-46d5-8e54-a800342f6740" /> <br> <img width="200" alt="Screenshot 2025-03-12 at 23 35 59" src="https://github.com/user-attachments/assets/2a4fe5cc-727e-46d8-b57d-f8d3c12ed288" /> |

Fixes #434 