### PR TITLE
Changed Delete button label to Uninstall

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="disable">Disable</string>
     <string name="not_working"><u>Not working?</u></string>
     <string name="info">Info</string>
-    <string name="delete">Delete</string>
+    <string name="delete">Uninstall</string>
     <string name="text_size">Text size</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>


### PR DESCRIPTION
fixes https://github.com/tanujnotes/Olauncher/issues/616
The first button in the context menu is labeled “Delete,” which can be a bit misleading. It makes it seem like the app will just be removed from the App Drawer — like it's being hidden — rather than actually uninstalled.

Since “Delete” sounds more like “Hide,” but ends up doing an “Uninstall,” it could confuse some users. Even though most people don’t uninstall apps that often, it’s still worth using clearer, more familiar terms like “Uninstall,” “Hide,” or “Disable.” These are widely understood and make it easier to know exactly what’s going to happen.