### PR TITLE
Fixed app options drawer dismiss bug

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@
     <string name="disable">Disable</string>
     <string name="not_working"><u>Not working?</u></string>
     <string name="info">Info</string>
-    <string name="delete">Delete</string>
+    <string name="delete">Uninstall</string>
     <string name="text_size">Text size</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>


### PR DESCRIPTION

fixes https://github.com/tanujnotes/Olauncher/issues/618
This PR fixes a bug in the app drawer where multiple option menus could remain open when long-pressing on different apps. Now, when a user long-presses on a new app, the options menu for any previously selected app is automatically hidden, ensuring only one menu is visible at a time for a cleaner and more intuitive UI experience. 