### PR TITLE
Fixed Typo in appActivityClassNameSwipeRight

### DIFF
--- a/app/src/main/java/app/olauncher/MainViewModel.kt
+++ b/app/src/main/java/app/olauncher/MainViewModel.kt
@@ -140,7 +140,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 prefs.appNameSwipeRight = appModel.appLabel
                 prefs.appPackageSwipeRight = appModel.appPackage
                 prefs.appUserSwipeRight = appModel.user.toString()
-                prefs.appActivityClassNameRight = appModel.activityClassName
+                prefs.appActivityClassNameSwipeRight = appModel.activityClassName
                 updateSwipeApps()
             }
 

--- a/app/src/main/java/app/olauncher/data/Prefs.kt
+++ b/app/src/main/java/app/olauncher/data/Prefs.kt
@@ -363,7 +363,7 @@ class Prefs(context: Context) {
         get() = prefs.getString(APP_PACKAGE_SWIPE_RIGHT, "").toString()
         set(value) = prefs.edit().putString(APP_PACKAGE_SWIPE_RIGHT, value).apply()
 
-    var appActivityClassNameRight: String?
+    var appActivityClassNameSwipeRight: String?
         get() = prefs.getString(APP_ACTIVITY_CLASS_NAME_SWIPE_RIGHT, "").toString()
         set(value) = prefs.edit().putString(APP_ACTIVITY_CLASS_NAME_SWIPE_RIGHT, value).apply()
 

--- a/app/src/main/java/app/olauncher/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/HomeFragment.kt
@@ -426,7 +426,7 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
             launchApp(
                 prefs.appNameSwipeRight,
                 prefs.appPackageSwipeRight,
-                prefs.appActivityClassNameRight,
+                prefs.appActivityClassNameSwipeRight,
                 prefs.appUserSwipeRight
             )
         else openDialerApp(requireContext())


### PR DESCRIPTION
Was previously appActivityClassNameRight, inconsistent with APP_ACTIVITY_CLASS_NAME_SWIPE_RIGHT and appActivityClassNameSwipeLeft