### PR TITLE
feat(apps): app drawer obeys home alignment

### DIFF
--- a/app/src/main/java/app/olauncher/MainViewModel.kt
+++ b/app/src/main/java/app/olauncher/MainViewModel.kt
@@ -48,6 +48,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val isOlauncherDefault = MutableLiveData<Boolean>()
     val launcherResetFailed = MutableLiveData<Boolean>()
     val homeAppAlignment = MutableLiveData<Int>()
+    val appLabelAlignment = MutableLiveData<Int>()
     val screenTimeValue = MutableLiveData<String>()
 
     val showDialog = SingleLiveEvent<String>()
@@ -253,6 +254,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun updateHomeAlignment(gravity: Int) {
         prefs.homeAlignment = gravity
         homeAppAlignment.value = prefs.homeAlignment
+    }
+
+    fun updateAppAlignment(gravity: Int) {
+        prefs.appLabelAlignment = gravity
+        appLabelAlignment.value = prefs.appLabelAlignment
+    }
+
+    fun updateAllAlignment(gravity: Int) {
+        updateHomeAlignment(gravity)
+        updateAppAlignment(gravity)
     }
 
     fun getTodaysScreenTime() {

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -1,6 +1,7 @@
 package app.olauncher.ui
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -58,6 +59,7 @@ class AppDrawerFragment : Fragment() {
             flag = it.getInt(Constants.Key.FLAG, Constants.FLAG_LAUNCH_APP)
             canRename = it.getBoolean(Constants.Key.RENAME, false)
         }
+        setAppAlignment(prefs.appLabelAlignment)
         initViews()
         initSearch()
         initAdapter()
@@ -283,5 +285,9 @@ class AppDrawerFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun setAppAlignment(horizontalGravity: Int = prefs.appLabelAlignment) {
+        viewModel.updateAppAlignment(horizontalGravity)
     }
 }

--- a/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
@@ -106,9 +106,10 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             R.id.dailyWallpaperUrl -> requireContext().openUrl(prefs.dailyWallpaperUrl)
             R.id.dailyWallpaper -> toggleDailyWallpaperUpdate()
             R.id.alignment -> binding.alignmentSelectLayout.visibility = View.VISIBLE
-            R.id.alignmentLeft -> viewModel.updateHomeAlignment(Gravity.START)
-            R.id.alignmentCenter -> viewModel.updateHomeAlignment(Gravity.CENTER)
-            R.id.alignmentRight -> viewModel.updateHomeAlignment(Gravity.END)
+            // TODO separate setting for app drawer alignment?
+            R.id.alignmentLeft -> viewModel.updateAllAlignment(Gravity.START)
+            R.id.alignmentCenter -> viewModel.updateAllAlignment(Gravity.CENTER)
+            R.id.alignmentRight -> viewModel.updateAllAlignment(Gravity.END)
             R.id.alignmentBottom -> updateHomeBottomAlignment()
             R.id.statusBar -> toggleStatusBar()
             R.id.dateTime -> binding.dateTimeSelectLayout.visibility = View.VISIBLE
@@ -546,6 +547,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         prefs.homeBottomAlignment = !prefs.homeBottomAlignment
         populateAlignment()
         viewModel.updateHomeAlignment(prefs.homeAlignment)
+        viewModel.updateAppAlignment(prefs.homeAlignment)
     }
 
     private fun populateAlignment() {


### PR DESCRIPTION
This sets the app drawer to use the same alignment as the home screen. This is probably not the preferred behavior, but is very easy to adapt if another setting is added to utilize that instead. I am a backend developer though, and barely was able to get this change working :sweat_smile:

Tested in android studio on virtual device.