### PR TITLE
Added feature to 'dim' the current wallpaper 

### DIFF
--- a/app/src/main/java/app/olauncher/data/Constants.kt
+++ b/app/src/main/java/app/olauncher/data/Constants.kt
@@ -56,6 +56,19 @@ object Constants {
         const val SEVEN = 1.3f
     }
 
+    object WallpaperDim {
+        const val ZERO = 0.0f
+        const val ONE = 0.1f
+        const val TWO = 0.2f
+        const val THREE = 0.3f
+        const val FOUR = 0.4f
+        const val FIVE = 0.5f
+        const val SIX = 0.6f
+        const val SEVEN = 0.7f
+        const val EIGHT = 0.8f
+        const val NINE = 0.9f
+    }
+
     object CharacterIndicator{
         const val SHOW = 102
         const val HIDE = 101

--- a/app/src/main/java/app/olauncher/data/Prefs.kt
+++ b/app/src/main/java/app/olauncher/data/Prefs.kt
@@ -37,6 +37,7 @@ class Prefs(context: Context) {
     private val SHARE_SHOWN_TIME = "SHARE_SHOWN_TIME"
     private val SWIPE_DOWN_ACTION = "SWIPE_DOWN_ACTION"
     private val TEXT_SIZE_SCALE = "TEXT_SIZE_SCALE"
+    private val WALLPAPER_DIM = "WALLPAPER_DIM"
     private val PRO_MESSAGE_SHOWN = "PRO_MESSAGE_SHOWN"
     private val HIDE_SET_DEFAULT_LAUNCHER = "HIDE_SET_DEFAULT_LAUNCHER"
     private val SCREEN_TIME_LAST_UPDATED = "SCREEN_TIME_LAST_UPDATED"
@@ -170,6 +171,10 @@ class Prefs(context: Context) {
     var textSizeScale: Float
         get() = prefs.getFloat(TEXT_SIZE_SCALE, 1.0f)
         set(value) = prefs.edit().putFloat(TEXT_SIZE_SCALE, value).apply()
+
+    var wallpaperDim: Float
+        get() = prefs.getFloat(WALLPAPER_DIM, 0.0f)
+        set(value) = prefs.edit().putFloat(WALLPAPER_DIM, value).apply()
 
     var proMessageShown: Boolean
         get() = prefs.getBoolean(PRO_MESSAGE_SHOWN, false)

--- a/app/src/main/java/app/olauncher/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/HomeFragment.kt
@@ -73,6 +73,7 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
 
         initObservers()
         setHomeAlignment(prefs.homeAlignment)
+        setWallpaperDim()
         initSwipeTouchListener()
         initClickListeners()
     }
@@ -597,6 +598,10 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
                 textOnClick(view)
             }
         }
+    }
+
+    private fun setWallpaperDim() {
+        binding.dimOverlay.alpha = prefs.wallpaperDim
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
@@ -67,6 +67,8 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         componentName = ComponentName(requireContext(), DeviceAdmin::class.java)
         checkAdminPermission()
 
+        setWallpaperDim()
+
         binding.homeAppsNum.text = prefs.homeAppsNum.toString()
         populateProMessage()
         populateKeyboardText()
@@ -75,6 +77,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         populateWallpaperText()
         populateAppThemeText()
         populateTextSize()
+        populateWallpaperDim()
         populateAlignment()
         populateStatusBar()
         populateDateTime()
@@ -91,6 +94,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         binding.appThemeSelectLayout.visibility = View.GONE
         binding.swipeDownSelectLayout.visibility = View.GONE
         binding.textSizesLayout.visibility = View.GONE
+        binding.wallpaperDimSizesLayout.visibility = View.GONE
         if (view.id != R.id.alignmentBottom)
             binding.alignmentSelectLayout.visibility = View.GONE
 
@@ -120,6 +124,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             R.id.themeDark -> updateTheme(AppCompatDelegate.MODE_NIGHT_YES)
             R.id.themeSystem -> updateTheme(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             R.id.textSizeValue -> binding.textSizesLayout.visibility = View.VISIBLE
+            R.id.wallpaperDimValue -> binding.wallpaperDimSizesLayout.visibility = View.VISIBLE
             R.id.actionAccessibility -> openAccessibilityService()
             R.id.closeAccessibility -> toggleAccessibilityVisibility(false)
             R.id.notWorking -> requireContext().openUrl(Constants.URL_DOUBLE_TAP)
@@ -143,6 +148,17 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             R.id.textSize5 -> updateTextSizeScale(Constants.TextSize.FIVE)
             R.id.textSize6 -> updateTextSizeScale(Constants.TextSize.SIX)
             R.id.textSize7 -> updateTextSizeScale(Constants.TextSize.SEVEN)
+
+            R.id.wallpaperDimZero -> updateWallpaperDim(Constants.WallpaperDim.ZERO)
+            R.id.wallpaperDim1 -> updateWallpaperDim(Constants.WallpaperDim.ONE)
+            R.id.wallpaperDim2 -> updateWallpaperDim(Constants.WallpaperDim.TWO)
+            R.id.wallpaperDim3 -> updateWallpaperDim(Constants.WallpaperDim.THREE)
+            R.id.wallpaperDim4 -> updateWallpaperDim(Constants.WallpaperDim.FOUR)
+            R.id.wallpaperDim5 -> updateWallpaperDim(Constants.WallpaperDim.FIVE)
+            R.id.wallpaperDim6 -> updateWallpaperDim(Constants.WallpaperDim.SIX)
+            R.id.wallpaperDim7 -> updateWallpaperDim(Constants.WallpaperDim.SEVEN)
+            R.id.wallpaperDim8 -> updateWallpaperDim(Constants.WallpaperDim.EIGHT)
+            R.id.wallpaperDim9 -> updateWallpaperDim(Constants.WallpaperDim.NINE)
 
             R.id.swipeLeftApp -> showAppListIfEnabled(Constants.FLAG_SET_SWIPE_LEFT_APP)
             R.id.swipeRightApp -> showAppListIfEnabled(Constants.FLAG_SET_SWIPE_RIGHT_APP)
@@ -222,6 +238,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         binding.themeDark.setOnClickListener(this)
         binding.themeSystem.setOnClickListener(this)
         binding.textSizeValue.setOnClickListener(this)
+        binding.wallpaperDimValue.setOnClickListener(this)
         binding.actionAccessibility.setOnClickListener(this)
         binding.closeAccessibility.setOnClickListener(this)
         binding.notWorking.setOnClickListener(this)
@@ -250,6 +267,17 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         binding.textSize5.setOnClickListener(this)
         binding.textSize6.setOnClickListener(this)
         binding.textSize7.setOnClickListener(this)
+
+        binding.wallpaperDimZero.setOnClickListener(this)
+        binding.wallpaperDim1.setOnClickListener(this)
+        binding.wallpaperDim2.setOnClickListener(this)
+        binding.wallpaperDim3.setOnClickListener(this)
+        binding.wallpaperDim4.setOnClickListener(this)
+        binding.wallpaperDim5.setOnClickListener(this)
+        binding.wallpaperDim6.setOnClickListener(this)
+        binding.wallpaperDim7.setOnClickListener(this)
+        binding.wallpaperDim8.setOnClickListener(this)
+        binding.wallpaperDim9.setOnClickListener(this)
 
         binding.dailyWallpaper.setOnLongClickListener(this)
         binding.alignment.setOnLongClickListener(this)
@@ -462,6 +490,12 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         requireActivity().recreate()
     }
 
+    private fun updateWallpaperDim(dim: Float) {
+        if (prefs.wallpaperDim == dim) return
+        prefs.wallpaperDim = dim
+        requireActivity().recreate()
+    }
+
     private fun toggleKeyboardText() {
         if (prefs.autoShowKeyboard && prefs.keyboardMessageShown.not()) {
             viewModel.showDialog.postValue(Constants.Dialog.KEYBOARD)
@@ -518,6 +552,22 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             Constants.TextSize.SIX -> 6
             Constants.TextSize.SEVEN -> 7
             else -> "--"
+        }.toString()
+    }
+
+    private fun populateWallpaperDim() {
+        binding.wallpaperDimValue.text = when (prefs.wallpaperDim) {
+            Constants.WallpaperDim.ZERO -> 0
+            Constants.WallpaperDim.ONE -> 1
+            Constants.WallpaperDim.TWO -> 2
+            Constants.WallpaperDim.THREE -> 3
+            Constants.WallpaperDim.FOUR -> 4
+            Constants.WallpaperDim.FIVE -> 5
+            Constants.WallpaperDim.SIX -> 6
+            Constants.WallpaperDim.SEVEN -> 7
+            Constants.WallpaperDim.EIGHT -> 8
+            Constants.WallpaperDim.NINE -> 9
+            else -> "0"
         }.toString()
     }
 
@@ -630,6 +680,10 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             prefs.proMessageShown = true
             viewModel.showDialog.postValue(Constants.Dialog.PRO_MESSAGE)
         }
+    }
+
+    private fun setWallpaperDim() {
+        binding.dimOverlay.alpha = prefs.wallpaperDim
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout-land/fragment_home.xml
+++ b/app/src/main/res/layout-land/fragment_home.xml
@@ -8,6 +8,14 @@
     android:orientation="vertical"
     tools:context=".ui.HomeFragment">
 
+    <!-- Overlay View for 'Dimming' wallpaper -->
+    <View
+        android:id="@+id/dim_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#000000"
+        android:alpha="0"/>
+
     <!-- Placeholder layout for locking screen-->
     <FrameLayout
         android:id="@+id/lock"

--- a/app/src/main/res/layout-land/fragment_settings.xml
+++ b/app/src/main/res/layout-land/fragment_settings.xml
@@ -7,6 +7,14 @@
     android:animateLayoutChanges="true"
     android:background="?attr/primaryShadeDarkColor">
 
+    <!-- Overlay View for 'Dimming' wallpaper -->
+    <View
+        android:id="@+id/dim_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#000000"
+        android:alpha="0"/>
+
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
@@ -749,6 +757,154 @@
 
                     </LinearLayout>
 
+                </FrameLayout>
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp"
+                    android:animateLayoutChanges="true"
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
+
+                    <TextView
+                        style="@style/TextSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:paddingVertical="8dp"
+                        android:text="@string/wallpaper_dim"
+                        android:textColor="?attr/primaryColor" />
+
+                    <TextView
+                        android:id="@+id/wallpaperDimValue"
+                        style="@style/TextSmallBold"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="4dp"
+                        android:paddingVertical="8dp"
+                        android:paddingStart="24dp"
+                        android:paddingEnd="8dp"
+                        tools:text="@string/_8" />
+
+                    <!-- Text sizes layout-->
+                    <LinearLayout
+                        android:id="@+id/wallpaperDimSizesLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:animateLayoutChanges="true"
+                        android:background="@drawable/rounded_primary_gradient"
+                        android:elevation="8dp"
+                        android:orientation="horizontal"
+                        android:outlineAmbientShadowColor="@color/colorPrimaryDark"
+                        android:outlineSpotShadowColor="@color/colorPrimaryDark"
+                        android:visibility="gone"
+                        tools:ignore="UnusedAttribute"
+                        tools:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/wallpaperDimZero"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_0" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim1"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_1" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim2"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_2" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim3"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_3" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim4"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_4" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim5"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_5" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim6"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_6" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim7"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_7" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim8"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_8" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim9"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_9" />
+
+                    </LinearLayout>
                 </FrameLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -8,6 +8,14 @@
     android:orientation="vertical"
     tools:context=".ui.HomeFragment">
 
+    <!-- Overlay View for 'Dimming' wallpaper -->
+    <View
+        android:id="@+id/dim_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#000000"
+        android:alpha="0"/>
+
     <!-- Placeholder layout for locking screen-->
     <FrameLayout
         android:id="@+id/lock"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -8,6 +8,14 @@
     android:animateLayoutChanges="true"
     android:background="?attr/primaryShadeDarkColor">
 
+    <!-- Overlay View for 'Dimming' wallpaper -->
+    <View
+        android:id="@+id/dim_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#000000"
+        android:alpha="0"/>
+
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
@@ -659,7 +667,6 @@
                     android:animateLayoutChanges="true"
                     android:clipChildren="false"
                     android:clipToPadding="false">
-
                     <TextView
                         style="@style/TextSmall"
                         android:layout_width="wrap_content"
@@ -767,7 +774,154 @@
                             android:text="@string/_7" />
 
                     </LinearLayout>
+                </FrameLayout>
 
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp"
+                    android:animateLayoutChanges="true"
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
+
+                    <TextView
+                        style="@style/TextSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:paddingVertical="8dp"
+                        android:text="@string/wallpaper_dim"
+                        android:textColor="?attr/primaryColor" />
+
+                    <TextView
+                        android:id="@+id/wallpaperDimValue"
+                        style="@style/TextSmallBold"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="4dp"
+                        android:paddingVertical="8dp"
+                        android:paddingStart="24dp"
+                        android:paddingEnd="8dp"
+                        tools:text="@string/_8" />
+
+                    <!-- Text sizes layout-->
+                    <LinearLayout
+                        android:id="@+id/wallpaperDimSizesLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:animateLayoutChanges="true"
+                        android:background="@drawable/rounded_primary_gradient"
+                        android:elevation="8dp"
+                        android:orientation="horizontal"
+                        android:outlineAmbientShadowColor="@color/colorPrimaryDark"
+                        android:outlineSpotShadowColor="@color/colorPrimaryDark"
+                        android:visibility="gone"
+                        tools:ignore="UnusedAttribute"
+                        tools:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/wallpaperDimZero"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_0" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim1"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_1" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim2"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_2" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim3"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_3" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim4"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_4" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim5"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_5" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim6"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_6" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim7"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_7" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim8"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_8" />
+
+                        <TextView
+                            android:id="@+id/wallpaperDim9"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_9" />
+
+                    </LinearLayout>
                 </FrameLayout>
 
             </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -13,6 +13,7 @@
     <string name="_6">ستة</string>
     <string name="_7">سبعة</string>
     <string name="_8">ثمانية</string>
+    <string name="_9">تسعة</string>
     <string name="app_drawer_tips">نصيحة: ابدأ في كتابة اسم التطبيق لتشغيله تلقائيًا</string>
     <string name="okay">حسنًا</string>
     <string name="cool">رائع!</string>
@@ -38,6 +39,7 @@
     <string name="info">معلومات</string>
     <string name="delete">يمسح</string>
     <string name="text_size">حجم الخط</string>
+    <string name="wallpaper_dim">إعتام الخلفية</string>
     <string name="enabled">ممكّن</string>
     <string name="disabled">مُطفأ</string>
     <string name="please_turn_on_double_tap_to_unlock">يرجى تشغيل النقر المزدوج لفتح القفل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,6 +13,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Tipp: Beginnen Sie mit der Eingabe eines App-Namens, um sie automatisch zu starten</string>
     <string name="okay">Okay</string>
     <string name="cool">Cool!</string>
@@ -38,6 +39,7 @@
     <string name="info">Die Info</string>
     <string name="delete">Löschen</string>
     <string name="text_size">Textgröße</string>
+    <string name="wallpaper_dim">Hintergrundbild abdunkeln</string>
     <string name="enabled">Aktiviert</string>
     <string name="disabled">Deaktiviert</string>
     <string name="please_turn_on_double_tap_to_unlock">Zum Sperren bitte Doppeltippen aktivieren</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Sugerencia: Comienza a escribir el nombre de una aplicación para iniciarla automáticamente</string>
     <string name="okay">De acuerdo</string>
     <string name="cool">¡Guay!</string>
@@ -104,6 +105,7 @@
     <string name="info">Información</string>
     <string name="delete">Desinstalar</string>
     <string name="text_size">Tamaño del texto</string>
+    <string name="wallpaper_dim">Oscurecer fondo de pantalla</string>
     <string name="enabled">Activado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Active el bloqueo con doble toque</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Sugerencia: Comienze a escribir el nombre de una aplicación para abrirla automáticamente</string>
     <string name="okay">Bueno</string>
     <string name="cool">¡Fresco!</string>
@@ -101,6 +102,7 @@
     <string name="info">Información</string>
     <string name="delete">Borrar</string>
     <string name="text_size">Tamaño del texto</string>
+    <string name="wallpaper_dim">Oscurecer fondo de pantalla</string>
     <string name="enabled">Activado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Active el doble toque para bloquear</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Conseil : Commencez à saisir le nom d\'une application pour la lancer automatiquement.</string>
     <string name="okay">D\'accord</string>
     <string name="cool">Cool !</string>
@@ -104,6 +105,7 @@
     <string name="delete">Supprimer</string>
     <string name="day_battery" formatted="false">%s, %d%%</string>
     <string name="text_size">Taille du texte</string>
+    <string name="wallpaper_dim">Assombrir le fond d'écran</string>
     <string name="enabled">Activé</string>
     <string name="disabled">Désactivé</string>
     <string name="please_turn_on_double_tap_to_unlock">Veuillez appuyer deux fois pour verrouiller.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Savjet: Povuci prema dolje za zatvaranje. Pomakni zaslon za zatvaranje tipkovnice.</string>
     <string name="okay">U redu</string>
     <string name="cool">Cool!</string>
@@ -110,6 +111,7 @@
     <string name="info">Informacije</string>
     <string name="delete">Izbriši</string>
     <string name="text_size">Veličina teksta</string>
+    <string name="wallpaper_dim">Zastućiti pozadinu</string>
     <string name="enabled">Omogućeno</string>
     <string name="disabled">Onemogućeno</string>
     <string name="please_turn_on_double_tap_to_unlock">Molimo vas da uključite dvostruki dodir za otključavanje</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -38,6 +38,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Tipp: Kezdje el begépelni egy alkalmazás nevét annak automatikus indításához</string>
     <string name="okay">Rendben</string>
     <string name="cool">Szuper!</string>
@@ -105,6 +106,7 @@
     <string name="info">Információ</string>
     <string name="delete">Törlés</string>
     <string name="text_size">Szövegméret</string>
+    <string name="wallpaper_dim">Háttérkép elsötétítése</string>
     <string name="enabled">Engedélyezve</string>
     <string name="disabled">Letiltva</string>
     <string name="please_turn_on_double_tap_to_unlock">Kérjük, kapcsolja be a dupla koppintást a lezáráshoz</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Kiat: Mulai ketikkan nama aplikasi untuk meluncurkannya secara otomatis</string>
     <string name="okay">Oke</string>
     <string name="cool">Keren!</string>
@@ -101,6 +102,7 @@
     <string name="info">Info</string>
     <string name="delete">Hapus</string>
     <string name="text_size">Ukuran teks</string>
+    <string name="wallpaper_dim">Redupkan wallpaper</string>
     <string name="enabled">Diaktifkan</string>
     <string name="disabled">Dinonaktifkan</string>
     <string name="please_turn_on_double_tap_to_unlock">Harap aktifkan ketuk dua kali untuk mengunci</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,6 +39,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Suggerimento: inizia a digitare il nome di un\'app per avviarla automaticamente</string>
     <string name="okay">OK</string>
     <string name="cool">Freddo</string>
@@ -103,6 +104,7 @@
     <string name="info" formatted="false">Informazioni</string>
     <string name="delete">Elimina</string>
     <string name="text_size">Dimensione del testo</string>
+    <string name="wallpaper_dim">Scurire lo sfondo</string>
     <string name="enabled">Abilitato</string>
     <string name="disabled">Disabilitato</string>
     <string name="please_turn_on_double_tap_to_unlock">Attiva il doppio tocco per sbloccare</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -13,6 +13,7 @@
     <string name="_6">六</string>
     <string name="_7">七</string>
     <string name="_8">八</string>
+    <string name="_9">九</string>
     <string name="app_drawer_tips">ヒント: アプリ名の入力を開始すると、アプリが自動的に起動します</string>
     <string name="okay">わかった</string>
     <string name="cool">いいね！</string>
@@ -39,6 +40,7 @@
     <string name="info">情報</string>
     <string name="delete">消去</string>
     <string name="text_size">文字サイズ</string>
+    <string name="wallpaper_dim">壁紙を暗くする</string>
     <string name="enabled">有効</string>
     <string name="disabled">無効</string>
     <string name="please_turn_on_double_tap_to_unlock">ダブルタップしてロックをオンにしてください</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -13,6 +13,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Wskazówka: zacznij wpisywać nazwę aplikacji, aby uruchomić ją automatycznie</string>
     <string name="okay">OK</string>
     <string name="cool">Fajny!</string>
@@ -38,6 +39,7 @@
     <string name="info">Informacje</string>
     <string name="delete">Usuń</string>
     <string name="text_size">Rozmiar czcionki</string>
+    <string name="wallpaper_dim">Przygaszenie tapety</string>
     <string name="enabled">Włączony</string>
     <string name="disabled">Wyłączony</string>
     <string name="please_turn_on_double_tap_to_unlock">Włącz podwójne dotknięcie, aby zablokować</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Dica: comece a digitar um nome de aplicativo para iniciá-lo automaticamente</string>
     <string name="okay">Ok</string>
     <string name="cool">Boa!</string>
@@ -104,6 +105,7 @@
     <string name="delete">Desinstalar</string>
     <string name="day_battery" formatted="false">%s, %d%%</string>
     <string name="text_size">Tamanho do texto</string>
+    <string name="wallpaper_dim">Escurecer papel de parede</string>
     <string name="enabled">Habilitado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Ative o toque duplo para bloquear</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Совет: начните вводить название приложения, чтобы запустить его автоматически.</string>
     <string name="okay">Хорошо</string>
     <string name="cool">Круто!</string>
@@ -104,6 +105,7 @@
     <string name="info">Информация</string>
     <string name="delete">Удалить</string>
     <string name="text_size">Размер текста</string>
+    <string name="wallpaper_dim">Затемнить обои</string>
     <string name="enabled">Включено</string>
     <string name="disabled">Выключено</string>
     <string name="please_turn_on_double_tap_to_unlock">Пожалуйста, включите двойное касание для блокировки</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -39,6 +39,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Tips: Börja skriv namnet på en app för att autostarta den</string>
     <string name="okay">Okej</string>
     <string name="cool">Coolt!</string>
@@ -102,6 +103,7 @@
     <string name="info">Info</string>
     <string name="delete">Radera</string>
     <string name="text_size">Textstorlek</string>
+    <string name="wallpaper_dim">Dämpa bakgrundsbild</string>
     <string name="enabled">Aktiverad</string>
     <string name="disabled">Inaktiverad</string>
     <string name="please_turn_on_double_tap_to_unlock">Vänligen sätt på dubbeltryck för att låsa</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -13,6 +13,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">İpucu: Otomatik olarak başlatmak için bir uygulama adı yazmaya başlayın</string>
     <string name="okay">Tamam</string>
     <string name="cool">Serin!</string>
@@ -38,6 +39,7 @@
     <string name="info">Bilgi</string>
     <string name="delete">Silmek</string>
     <string name="text_size">Yazı Boyutu</string>
+    <string name="wallpaper_dim">Duvar kağıdını karart</string>
     <string name="enabled">Etkinleştirilmiş</string>
     <string name="disabled">Engelli</string>
     <string name="please_turn_on_double_tap_to_unlock">Lütfen kilitlemek için çift dokunmayı açın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -40,6 +40,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Порада. Почніть вводити назву програми, щоб вона запустилася автоматично.</string>
     <string name="okay">Добре</string>
     <string name="cool">Круто!</string>
@@ -104,6 +105,7 @@
     <string name="info">Інформація</string>
     <string name="delete">Видалити</string>
     <string name="text_size">Розмір тексту</string>
+    <string name="wallpaper_dim">Затінити шпалери</string>
     <string name="enabled">Включено</string>
     <string name="disabled">Виключено</string>
     <string name="please_turn_on_double_tap_to_unlock">Будь ласка, увімкніть подвійний дотик для блокування</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -29,6 +29,8 @@
     <string name="info">信息</string>
     <string name="delete">删除</string>
     <string name="text_size">字体大小</string>
+    <string name="_9">9</string>
+    <string name="wallpaper_dim">调暗壁纸</string>
     <string name="enabled">启用</string>
     <string name="disabled">禁用</string>
     <string name="please_turn_on_double_tap_to_unlock">请打开双击以锁定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="_6">6</string>
     <string name="_7">7</string>
     <string name="_8">8</string>
+    <string name="_9">9</string>
     <string name="app_drawer_tips">Tip: Start typing an app name to auto-launch it</string>
     <string name="okay">Okay</string>
     <string name="cool">Cool!</string>
@@ -121,6 +122,7 @@
     <string name="info">Info</string>
     <string name="delete">Delete</string>
     <string name="text_size">Text size</string>
+    <string name="wallpaper_dim">Dim Wallpaper</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>
     <string name="please_turn_on_double_tap_to_unlock">Please turn on double tap to lock</string>


### PR DESCRIPTION
## Summary

The default black and white text can sometimes be difficult to read depending on the current wallpaper.  Add wallpaper dimming feature allowing users to adjust background darkness from 0-90% opacity. 

 ## Changes
  - New wallpaper dim setting with 10 levels (0-9) ignored 10 as it seemed redundant.
  -  UI controls in Settings page.
  - Translations added for all 17 supported languages.

## Screenshots 
Wallpaper dim 0:
<img width="270" height="600" alt="wall_zero_dim" src="https://github.com/user-attachments/assets/a0e18f7b-87af-4d19-9bf2-43004ad1b311" />

Wallpaper dim setting:
<img width="270" height="600" alt="wallpaper_dim_setting" src="https://github.com/user-attachments/assets/7924fdc9-9f34-4496-aa94-1020f8bb223f" />

Wallpaper dim select: 
<img width="270" height="600" alt="wallpaper_dim_select" src="https://github.com/user-attachments/assets/6118e5d5-f5ed-4b4b-9f37-ac36009b99ce" />


Wallpaper dim 7: 
<img width="270" height="600" alt="wallpaper_dim_7" src="https://github.com/user-attachments/assets/9d76d5f2-63f4-4ebe-a481-51281de7fbde" />

## Additional comments 

- Used LLM to generate language translations. 
- Tried to keep things consistent with TextSize implementation.
- Tested on simulator and on the device I have.
- Let me know if there are any major issues. I mostly developer in Flutter so not super familiar with native Android development 😄.