### PR TITLE
Add separate clock size setting

### DIFF
--- a/app/src/main/java/app/olauncher/data/Constants.kt
+++ b/app/src/main/java/app/olauncher/data/Constants.kt
@@ -56,6 +56,16 @@ object Constants {
         const val SEVEN = 1.3f
     }
 
+    object ClockSize {
+        const val ONE = 0.6f
+        const val TWO = 0.75f
+        const val THREE = 0.9f
+        const val FOUR = 1f
+        const val FIVE = 1.1f
+        const val SIX = 1.2f
+        const val SEVEN = 1.3f
+    }
+
     object CharacterIndicator {
         const val SHOW = 102
         const val HIDE = 101

--- a/app/src/main/java/app/olauncher/data/Prefs.kt
+++ b/app/src/main/java/app/olauncher/data/Prefs.kt
@@ -37,6 +37,7 @@ class Prefs(context: Context) {
     private val SHARE_SHOWN_TIME = "SHARE_SHOWN_TIME"
     private val SWIPE_DOWN_ACTION = "SWIPE_DOWN_ACTION"
     private val TEXT_SIZE_SCALE = "TEXT_SIZE_SCALE"
+    private val CLOCK_SIZE_SCALE = "CLOCK_SIZE_SCALE"
     private val PRO_MESSAGE_SHOWN = "PRO_MESSAGE_SHOWN"
     private val HIDE_SET_DEFAULT_LAUNCHER = "HIDE_SET_DEFAULT_LAUNCHER"
     private val SCREEN_TIME_LAST_UPDATED = "SCREEN_TIME_LAST_UPDATED"
@@ -172,6 +173,10 @@ class Prefs(context: Context) {
     var textSizeScale: Float
         get() = prefs.getFloat(TEXT_SIZE_SCALE, 1.0f)
         set(value) = prefs.edit { putFloat(TEXT_SIZE_SCALE, value).apply() }
+
+    var clockSizeScale: Float
+        get() = prefs.getFloat(CLOCK_SIZE_SCALE, 1.0f)
+        set(value) = prefs.edit { putFloat(CLOCK_SIZE_SCALE, value).apply() }
 
     var proMessageShown: Boolean
         get() = prefs.getBoolean(PRO_MESSAGE_SHOWN, false)

--- a/app/src/main/java/app/olauncher/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/HomeFragment.kt
@@ -241,6 +241,13 @@ class HomeFragment : Fragment(), View.OnClickListener, View.OnLongClickListener 
         binding.clock.isVisible = Constants.DateTime.isTimeVisible(prefs.dateTimeVisibility)
         binding.date.isVisible = Constants.DateTime.isDateVisible(prefs.dateTimeVisibility)
 
+        // Apply independent clock size
+        val clockScale = prefs.clockSizeScale / prefs.textSizeScale
+        val timeSize = resources.getDimension(R.dimen.time_size) * clockScale
+        val dateSize = resources.getDimension(R.dimen.date_size) * clockScale
+        binding.clock.textSize = timeSize / resources.displayMetrics.scaledDensity
+        binding.date.textSize = dateSize / resources.displayMetrics.scaledDensity
+
 //        var dateText = SimpleDateFormat("EEE, d MMM", Locale.getDefault()).format(Date())
         val dateFormat = SimpleDateFormat("EEE, d MMM", Locale.getDefault())
         var dateText = dateFormat.format(Date())

--- a/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/SettingsFragment.kt
@@ -75,6 +75,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         populateWallpaperText()
         populateAppThemeText()
         populateTextSize()
+        populateClockSize()
         populateAlignment()
         populateStatusBar()
         populateDateTime()
@@ -91,6 +92,7 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         binding.appThemeSelectLayout.visibility = View.GONE
         binding.swipeDownSelectLayout.visibility = View.GONE
         binding.textSizesLayout.visibility = View.GONE
+        binding.clockSizesLayout.visibility = View.GONE
         if (view.id != R.id.alignmentBottom)
             binding.alignmentSelectLayout.visibility = View.GONE
 
@@ -143,6 +145,15 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             R.id.textSize5 -> updateTextSizeScale(Constants.TextSize.FIVE)
             R.id.textSize6 -> updateTextSizeScale(Constants.TextSize.SIX)
             R.id.textSize7 -> updateTextSizeScale(Constants.TextSize.SEVEN)
+
+            R.id.clockSizeValue -> binding.clockSizesLayout.visibility = View.VISIBLE
+            R.id.clockSize1 -> updateClockSizeScale(Constants.ClockSize.ONE)
+            R.id.clockSize2 -> updateClockSizeScale(Constants.ClockSize.TWO)
+            R.id.clockSize3 -> updateClockSizeScale(Constants.ClockSize.THREE)
+            R.id.clockSize4 -> updateClockSizeScale(Constants.ClockSize.FOUR)
+            R.id.clockSize5 -> updateClockSizeScale(Constants.ClockSize.FIVE)
+            R.id.clockSize6 -> updateClockSizeScale(Constants.ClockSize.SIX)
+            R.id.clockSize7 -> updateClockSizeScale(Constants.ClockSize.SEVEN)
 
             R.id.swipeLeftApp -> showAppListIfEnabled(Constants.FLAG_SET_SWIPE_LEFT_APP)
             R.id.swipeRightApp -> showAppListIfEnabled(Constants.FLAG_SET_SWIPE_RIGHT_APP)
@@ -250,6 +261,15 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
         binding.textSize5.setOnClickListener(this)
         binding.textSize6.setOnClickListener(this)
         binding.textSize7.setOnClickListener(this)
+
+        binding.clockSizeValue.setOnClickListener(this)
+        binding.clockSize1.setOnClickListener(this)
+        binding.clockSize2.setOnClickListener(this)
+        binding.clockSize3.setOnClickListener(this)
+        binding.clockSize4.setOnClickListener(this)
+        binding.clockSize5.setOnClickListener(this)
+        binding.clockSize6.setOnClickListener(this)
+        binding.clockSize7.setOnClickListener(this)
 
         binding.dailyWallpaper.setOnLongClickListener(this)
         binding.alignment.setOnLongClickListener(this)
@@ -517,6 +537,26 @@ class SettingsFragment : Fragment(), View.OnClickListener, View.OnLongClickListe
             Constants.TextSize.FIVE -> 5
             Constants.TextSize.SIX -> 6
             Constants.TextSize.SEVEN -> 7
+            else -> "--"
+        }.toString()
+    }
+
+    private fun updateClockSizeScale(sizeScale: Float) {
+        if (prefs.clockSizeScale == sizeScale) return
+        prefs.clockSizeScale = sizeScale
+        populateClockSize()
+        viewModel.toggleDateTime()
+    }
+
+    private fun populateClockSize() {
+        binding.clockSizeValue.text = when (prefs.clockSizeScale) {
+            Constants.ClockSize.ONE -> 1
+            Constants.ClockSize.TWO -> 2
+            Constants.ClockSize.THREE -> 3
+            Constants.ClockSize.FOUR -> 4
+            Constants.ClockSize.FIVE -> 5
+            Constants.ClockSize.SIX -> 6
+            Constants.ClockSize.SEVEN -> 7
             else -> "--"
         }.toString()
     }

--- a/app/src/main/res/layout-land/fragment_settings.xml
+++ b/app/src/main/res/layout-land/fragment_settings.xml
@@ -751,6 +751,125 @@
 
                 </FrameLayout>
 
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp"
+                    android:animateLayoutChanges="true"
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
+
+                    <TextView
+                        style="@style/TextSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:paddingVertical="8dp"
+                        android:text="@string/clock_size"
+                        android:textColor="?attr/primaryColor" />
+
+                    <TextView
+                        android:id="@+id/clockSizeValue"
+                        style="@style/TextSmallBold"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="4dp"
+                        android:paddingVertical="8dp"
+                        android:paddingStart="24dp"
+                        android:paddingEnd="8dp"
+                        tools:text="@string/_4" />
+
+                    <!-- Clock sizes layout-->
+                    <LinearLayout
+                        android:id="@+id/clockSizesLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:animateLayoutChanges="true"
+                        android:background="@drawable/rounded_primary_gradient"
+                        android:elevation="8dp"
+                        android:orientation="horizontal"
+                        android:outlineAmbientShadowColor="@color/colorPrimaryDark"
+                        android:outlineSpotShadowColor="@color/colorPrimaryDark"
+                        android:visibility="gone"
+                        tools:ignore="UnusedAttribute"
+                        tools:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/clockSize1"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_1" />
+
+                        <TextView
+                            android:id="@+id/clockSize2"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_2" />
+
+                        <TextView
+                            android:id="@+id/clockSize3"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_3" />
+
+                        <TextView
+                            android:id="@+id/clockSize4"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_4" />
+
+                        <TextView
+                            android:id="@+id/clockSize5"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_5" />
+
+                        <TextView
+                            android:id="@+id/clockSize6"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_6" />
+
+                        <TextView
+                            android:id="@+id/clockSize7"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_7" />
+
+                    </LinearLayout>
+
+                </FrameLayout>
+
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -770,6 +770,125 @@
 
                 </FrameLayout>
 
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp"
+                    android:animateLayoutChanges="true"
+                    android:clipChildren="false"
+                    android:clipToPadding="false">
+
+                    <TextView
+                        style="@style/TextSmall"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:paddingVertical="8dp"
+                        android:text="@string/clock_size"
+                        android:textColor="?attr/primaryColor" />
+
+                    <TextView
+                        android:id="@+id/clockSizeValue"
+                        style="@style/TextSmallBold"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginEnd="4dp"
+                        android:paddingVertical="8dp"
+                        android:paddingStart="24dp"
+                        android:paddingEnd="8dp"
+                        tools:text="@string/_4" />
+
+                    <!-- Clock sizes layout-->
+                    <LinearLayout
+                        android:id="@+id/clockSizesLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:animateLayoutChanges="true"
+                        android:background="@drawable/rounded_primary_gradient"
+                        android:elevation="8dp"
+                        android:orientation="horizontal"
+                        android:outlineAmbientShadowColor="@color/colorPrimaryDark"
+                        android:outlineSpotShadowColor="@color/colorPrimaryDark"
+                        android:visibility="gone"
+                        tools:ignore="UnusedAttribute"
+                        tools:visibility="gone">
+
+                        <TextView
+                            android:id="@+id/clockSize1"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_1" />
+
+                        <TextView
+                            android:id="@+id/clockSize2"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_2" />
+
+                        <TextView
+                            android:id="@+id/clockSize3"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_3" />
+
+                        <TextView
+                            android:id="@+id/clockSize4"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_4" />
+
+                        <TextView
+                            android:id="@+id/clockSize5"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_5" />
+
+                        <TextView
+                            android:id="@+id/clockSize6"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_6" />
+
+                        <TextView
+                            android:id="@+id/clockSize7"
+                            style="@style/TextSmall"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="center"
+                            android:paddingVertical="8dp"
+                            android:text="@string/_7" />
+
+                    </LinearLayout>
+
+                </FrameLayout>
+
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -38,6 +38,7 @@
     <string name="info">معلومات</string>
     <string name="delete">يمسح</string>
     <string name="text_size">حجم الخط</string>
+    <string name="clock_size">حجم الساعة</string>
     <string name="enabled">ممكّن</string>
     <string name="disabled">مُطفأ</string>
     <string name="please_turn_on_double_tap_to_unlock">يرجى تشغيل النقر المزدوج لفتح القفل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -38,6 +38,7 @@
     <string name="info">Die Info</string>
     <string name="delete">Löschen</string>
     <string name="text_size">Textgröße</string>
+    <string name="clock_size">Uhrgröße</string>
     <string name="enabled">Aktiviert</string>
     <string name="disabled">Deaktiviert</string>
     <string name="please_turn_on_double_tap_to_unlock">Zum Sperren bitte Doppeltippen aktivieren</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -104,6 +104,7 @@
     <string name="info">Información</string>
     <string name="delete">Desinstalar</string>
     <string name="text_size">Tamaño del texto</string>
+    <string name="clock_size">Tamaño del reloj</string>
     <string name="enabled">Activado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Active el bloqueo con doble toque</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -101,6 +101,7 @@
     <string name="info">Información</string>
     <string name="delete">Borrar</string>
     <string name="text_size">Tamaño del texto</string>
+    <string name="clock_size">Tamaño del reloj</string>
     <string name="enabled">Activado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Active el doble toque para bloquear</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -103,6 +103,7 @@
     <string name="info">Info</string>
     <string name="delete">Supprimer</string>
     <string name="text_size">Taille du texte</string>
+    <string name="clock_size">Taille de l\'horloge</string>
     <string name="enabled">Activé</string>
     <string name="disabled">Désactivé</string>
     <string name="please_turn_on_double_tap_to_unlock">Veuillez appuyer deux fois pour verrouiller.</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -94,6 +94,7 @@
     <string name="info">מידע</string>
     <string name="delete">מחיקה</string>
     <string name="text_size">גודל הטקסט</string>
+    <string name="clock_size">גודל השעון</string>
     <string name="enabled">מופעל</string>
     <string name="disabled">מושבת</string>
     <string name="please_turn_on_double_tap_to_unlock">נא להפעיל את מחוות ההקשה הכפולה בשביל לצורך הנעילה</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -108,6 +108,7 @@
     <string name="info">Informacije</string>
     <string name="delete">Izbriši</string>
     <string name="text_size">Veličina teksta</string>
+    <string name="clock_size">Veličina sata</string>
     <string name="enabled">Omogućeno</string>
     <string name="disabled">Onemogućeno</string>
     <string name="please_turn_on_double_tap_to_unlock">Molimo vas da uključite dvostruki dodir za otključavanje</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -106,6 +106,7 @@
     <string name="info">Információ</string>
     <string name="delete">Törlés</string>
     <string name="text_size">Szövegméret</string>
+    <string name="clock_size">Óra mérete</string>
     <string name="enabled">Engedélyezve</string>
     <string name="disabled">Letiltva</string>
     <string name="please_turn_on_double_tap_to_unlock">Kérjük, kapcsolja be a dupla koppintást a lezáráshoz</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -101,6 +101,7 @@
     <string name="info">Info</string>
     <string name="delete">Hapus</string>
     <string name="text_size">Ukuran teks</string>
+    <string name="clock_size">Ukuran jam</string>
     <string name="enabled">Diaktifkan</string>
     <string name="disabled">Dinonaktifkan</string>
     <string name="please_turn_on_double_tap_to_unlock">Harap aktifkan ketuk dua kali untuk mengunci</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -104,6 +104,7 @@
     <string name="info" formatted="false">Informazioni</string>
     <string name="delete">Elimina</string>
     <string name="text_size">Dimensione del testo</string>
+    <string name="clock_size">Dimensione orologio</string>
     <string name="enabled">Abilitato</string>
     <string name="disabled">Disabilitato</string>
     <string name="please_turn_on_double_tap_to_unlock">Attiva il doppio tocco per sbloccare</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -39,6 +39,7 @@
     <string name="info">情報</string>
     <string name="delete">消去</string>
     <string name="text_size">文字サイズ</string>
+    <string name="clock_size">時計サイズ</string>
     <string name="enabled">有効</string>
     <string name="disabled">無効</string>
     <string name="please_turn_on_double_tap_to_unlock">ダブルタップしてロックをオンにしてください</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -38,6 +38,7 @@
     <string name="info">Informacje</string>
     <string name="delete">Usuń</string>
     <string name="text_size">Rozmiar czcionki</string>
+    <string name="clock_size">Rozmiar zegara</string>
     <string name="enabled">Włączony</string>
     <string name="disabled">Wyłączony</string>
     <string name="please_turn_on_double_tap_to_unlock">Włącz podwójne dotknięcie, aby zablokować</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -103,6 +103,7 @@
     <string name="info">Informação</string>
     <string name="delete">Desinstalar</string>
     <string name="text_size">Tamanho do texto</string>
+    <string name="clock_size">Tamanho do relógio</string>
     <string name="enabled">Habilitado</string>
     <string name="disabled">Desactivado</string>
     <string name="please_turn_on_double_tap_to_unlock">Ative o toque duplo para bloquear</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -104,6 +104,7 @@
     <string name="info">Информация</string>
     <string name="delete">Удалить</string>
     <string name="text_size">Размер текста</string>
+    <string name="clock_size">Размер часов</string>
     <string name="enabled">Включено</string>
     <string name="disabled">Выключено</string>
     <string name="please_turn_on_double_tap_to_unlock">Пожалуйста, включите двойное касание для блокировки</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -102,6 +102,7 @@
     <string name="info">Info</string>
     <string name="delete">Radera</string>
     <string name="text_size">Textstorlek</string>
+    <string name="clock_size">Klockstorlek</string>
     <string name="enabled">Aktiverad</string>
     <string name="disabled">Inaktiverad</string>
     <string name="please_turn_on_double_tap_to_unlock">Vänligen sätt på dubbeltryck för att låsa</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -38,6 +38,7 @@
     <string name="info">Bilgi</string>
     <string name="delete">Sil</string>
     <string name="text_size">Yazı Boyutu</string>
+    <string name="clock_size">Saat Boyutu</string>
     <string name="enabled">Etkin</string>
     <string name="disabled">Devre Dışı</string>
     <string name="please_turn_on_double_tap_to_unlock">Lütfen kilitlemek için çift dokunmayı açın</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -104,6 +104,7 @@
     <string name="info">Інформація</string>
     <string name="delete">Видалити</string>
     <string name="text_size">Розмір тексту</string>
+    <string name="clock_size">Розмір годинника</string>
     <string name="enabled">Включено</string>
     <string name="disabled">Виключено</string>
     <string name="please_turn_on_double_tap_to_unlock">Будь ласка, увімкніть подвійний дотик для блокування</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -29,6 +29,7 @@
     <string name="info">信息</string>
     <string name="delete">删除</string>
     <string name="text_size">字体大小</string>
+    <string name="clock_size">时钟大小</string>
     <string name="enabled">启用</string>
     <string name="disabled">禁用</string>
     <string name="please_turn_on_double_tap_to_unlock">请打开双击以锁定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="info">Info</string>
     <string name="delete">Delete</string>
     <string name="text_size">Text size</string>
+    <string name="clock_size">Clock size</string>
     <string name="enabled">Enabled</string>
     <string name="disabled">Disabled</string>
     <string name="please_turn_on_double_tap_to_unlock">Please turn on double tap to lock</string>


### PR DESCRIPTION
Allow users to set clock/date size independently from text size. This addresses the issue where users want small app text but a larger clock.

  - Resolves #643

- Add clockSizeScale preference
- Add Clock size UI in settings (1-7 scale options)
- Apply clock size programmatically to counteract global font scale
- Add translations for all 18 supported languages