### PR TITLE
Pinned Shortcut support (for example: PWA / Shortcuts to browser)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,20 @@
         </activity>
 
         <activity
+            android:name=".helper.PinItemActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.content.pm.action.CONFIRM_PIN_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.content.pm.action.CONFIRM_PIN_APPWIDGET" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".helper.FakeHomeActivity"
             android:enabled="false"
             android:exported="false"

--- a/app/src/main/java/app/olauncher/MainViewModel.kt
+++ b/app/src/main/java/app/olauncher/MainViewModel.kt
@@ -53,104 +53,257 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun selectedApp(appModel: AppModel, flag: Int) {
         when (flag) {
             Constants.FLAG_LAUNCH_APP -> {
-                launchApp(appModel.appPackage, appModel.activityClassName, appModel.user)
+                when (appModel) {
+                    is AppModel.PinnedShortcut -> launchShortcut(appModel)
+                    is AppModel.App ->
+                        launchApp(appModel.appPackage, appModel.activityClassName, appModel.user)
+                }
             }
 
             Constants.FLAG_HIDDEN_APPS -> {
-                launchApp(appModel.appPackage, appModel.activityClassName, appModel.user)
+                if (appModel is AppModel.App) {
+                    launchApp(appModel.appPackage, appModel.activityClassName, appModel.user)
+                }
             }
 
-            Constants.FLAG_SET_HOME_APP_1 -> {
-                prefs.appName1 = appModel.appLabel
-                prefs.appPackage1 = appModel.appPackage
-                prefs.appUser1 = appModel.user.toString()
-                prefs.appActivityClassName1 = appModel.activityClassName
-                refreshHome(false)
+            Constants.FLAG_SET_HOME_APP_1 -> saveHomeApp(appModel, 1)
+            Constants.FLAG_SET_HOME_APP_2 -> saveHomeApp(appModel, 2)
+            Constants.FLAG_SET_HOME_APP_3 -> saveHomeApp(appModel, 3)
+            Constants.FLAG_SET_HOME_APP_4 -> saveHomeApp(appModel, 4)
+            Constants.FLAG_SET_HOME_APP_5 -> saveHomeApp(appModel, 5)
+            Constants.FLAG_SET_HOME_APP_6 -> saveHomeApp(appModel, 6)
+            Constants.FLAG_SET_HOME_APP_7 -> saveHomeApp(appModel, 7)
+            Constants.FLAG_SET_HOME_APP_8 -> saveHomeApp(appModel, 8)
+
+            Constants.FLAG_SET_SWIPE_LEFT_APP -> saveSwipeApp(appModel, isLeft = true)
+            Constants.FLAG_SET_SWIPE_RIGHT_APP -> saveSwipeApp(appModel, isLeft = false)
+            Constants.FLAG_SET_CLOCK_APP -> saveClockApp(appModel)
+            Constants.FLAG_SET_CALENDAR_APP -> saveCalendarApp(appModel)
+        }
+    }
+
+    private fun launchShortcut(appModel: AppModel.PinnedShortcut) {
+        val launcher = appContext.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        val query = LauncherApps.ShortcutQuery().apply {
+            setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED)
+        }
+        launcher.getShortcuts(query, appModel.user)?.find { it.id == appModel.shortcutId }
+            ?.let { shortcut ->
+                launcher.startShortcut(shortcut, null, null)
+            }
+    }
+
+    private fun saveHomeApp(appModel: AppModel, position: Int) {
+        when (appModel) {
+            is AppModel.App -> {
+                when (position) {
+                    1 -> {
+                        prefs.appName1 = appModel.appLabel
+                        prefs.appPackage1 = appModel.appPackage
+                        prefs.appUser1 = appModel.user.toString()
+                        prefs.appActivityClassName1 = appModel.activityClassName
+                        prefs.isShortcut1 = false
+                        prefs.shortcutId1 = ""
+                    }
+
+                    2 -> {
+                        prefs.appName2 = appModel.appLabel
+                        prefs.appPackage2 = appModel.appPackage
+                        prefs.appUser2 = appModel.user.toString()
+                        prefs.appActivityClassName2 = appModel.activityClassName
+                        prefs.isShortcut2 = false
+                        prefs.shortcutId2 = ""
+                    }
+
+                    3 -> {
+                        prefs.appName3 = appModel.appLabel
+                        prefs.appPackage3 = appModel.appPackage
+                        prefs.appUser3 = appModel.user.toString()
+                        prefs.appActivityClassName3 = appModel.activityClassName
+                        prefs.isShortcut3 = false
+                        prefs.shortcutId3 = ""
+                    }
+
+                    4 -> {
+                        prefs.appName4 = appModel.appLabel
+                        prefs.appPackage4 = appModel.appPackage
+                        prefs.appUser4 = appModel.user.toString()
+                        prefs.appActivityClassName4 = appModel.activityClassName
+                        prefs.isShortcut4 = false
+                        prefs.shortcutId4 = ""
+                    }
+
+                    5 -> {
+                        prefs.appName5 = appModel.appLabel
+                        prefs.appPackage5 = appModel.appPackage
+                        prefs.appUser5 = appModel.user.toString()
+                        prefs.appActivityClassName5 = appModel.activityClassName
+                        prefs.isShortcut5 = false
+                        prefs.shortcutId5 = ""
+                    }
+
+                    6 -> {
+                        prefs.appName6 = appModel.appLabel
+                        prefs.appPackage6 = appModel.appPackage
+                        prefs.appUser6 = appModel.user.toString()
+                        prefs.appActivityClassName6 = appModel.activityClassName
+                        prefs.isShortcut6 = false
+                        prefs.shortcutId6 = ""
+                    }
+
+                    7 -> {
+                        prefs.appName7 = appModel.appLabel
+                        prefs.appPackage7 = appModel.appPackage
+                        prefs.appUser7 = appModel.user.toString()
+                        prefs.appActivityClassName7 = appModel.activityClassName
+                        prefs.isShortcut7 = false
+                        prefs.shortcutId7 = ""
+                    }
+
+                    8 -> {
+                        prefs.appName8 = appModel.appLabel
+                        prefs.appPackage8 = appModel.appPackage
+                        prefs.appUser8 = appModel.user.toString()
+                        prefs.appActivityClassName8 = appModel.activityClassName
+                        prefs.isShortcut8 = false
+                        prefs.shortcutId8 = ""
+                    }
+                }
             }
 
-            Constants.FLAG_SET_HOME_APP_2 -> {
-                prefs.appName2 = appModel.appLabel
-                prefs.appPackage2 = appModel.appPackage
-                prefs.appUser2 = appModel.user.toString()
-                prefs.appActivityClassName2 = appModel.activityClassName
-                refreshHome(false)
+            is AppModel.PinnedShortcut -> {
+                when (position) {
+                    1 -> {
+                        prefs.appName1 = appModel.appLabel
+                        prefs.appPackage1 = appModel.appPackage
+                        prefs.appUser1 = appModel.user.toString()
+                        prefs.appActivityClassName1 = null
+                        prefs.isShortcut1 = true
+                        prefs.shortcutId1 = appModel.shortcutId
+                    }
+
+                    2 -> {
+                        prefs.appName2 = appModel.appLabel
+                        prefs.appPackage2 = appModel.appPackage
+                        prefs.appUser2 = appModel.user.toString()
+                        prefs.appActivityClassName2 = null
+                        prefs.isShortcut2 = true
+                        prefs.shortcutId2 = appModel.shortcutId
+                    }
+
+                    3 -> {
+                        prefs.appName3 = appModel.appLabel
+                        prefs.appPackage3 = appModel.appPackage
+                        prefs.appUser3 = appModel.user.toString()
+                        prefs.appActivityClassName3 = null
+                        prefs.isShortcut3 = true
+                        prefs.shortcutId3 = appModel.shortcutId
+                    }
+
+                    4 -> {
+                        prefs.appName4 = appModel.appLabel
+                        prefs.appPackage4 = appModel.appPackage
+                        prefs.appUser4 = appModel.user.toString()
+                        prefs.appActivityClassName4 = null
+                        prefs.isShortcut4 = true
+                        prefs.shortcutId4 = appModel.shortcutId
+                    }
+
+                    5 -> {
+                        prefs.appName5 = appModel.appLabel
+                        prefs.appPackage5 = appModel.appPackage
+                        prefs.appUser5 = appModel.user.toString()
+                        prefs.appActivityClassName5 = null
+                        prefs.isShortcut5 = true
+                        prefs.shortcutId5 = appModel.shortcutId
+                    }
+
+                    6 -> {
+                        prefs.appName6 = appModel.appLabel
+                        prefs.appPackage6 = appModel.appPackage
+                        prefs.appUser6 = appModel.user.toString()
+                        prefs.appActivityClassName6 = null
+                        prefs.isShortcut6 = true
+                        prefs.shortcutId6 = appModel.shortcutId
+                    }
+
+                    7 -> {
+                        prefs.appName7 = appModel.appLabel
+                        prefs.appPackage7 = appModel.appPackage
+                        prefs.appUser7 = appModel.user.toString()
+                        prefs.appActivityClassName7 = null
+                        prefs.isShortcut7 = true
+                        prefs.shortcutId7 = appModel.shortcutId
+                    }
+
+                    8 -> {
+                        prefs.appName8 = appModel.appLabel
+                        prefs.appPackage8 = appModel.appPackage
+                        prefs.appUser8 = appModel.user.toString()
+                        prefs.appActivityClassName8 = null
+                        prefs.isShortcut8 = true
+                        prefs.shortcutId8 = appModel.shortcutId
+                    }
+                }
+            }
+        }
+        refreshHome(false)
+    }
+
+    private fun saveSwipeApp(appModel: AppModel, isLeft: Boolean) {
+        when (appModel) {
+            is AppModel.App -> {
+                if (isLeft) {
+                    prefs.appNameSwipeLeft = appModel.appLabel
+                    prefs.appPackageSwipeLeft = appModel.appPackage
+                    prefs.appUserSwipeLeft = appModel.user.toString()
+                    prefs.appActivityClassNameSwipeLeft = appModel.activityClassName
+                    prefs.isShortcutSwipeLeft = false
+                    prefs.shortcutIdSwipeLeft = ""
+                } else {
+                    prefs.appNameSwipeRight = appModel.appLabel
+                    prefs.appPackageSwipeRight = appModel.appPackage
+                    prefs.appUserSwipeRight = appModel.user.toString()
+                    prefs.appActivityClassNameRight = appModel.activityClassName
+                    prefs.isShortcutSwipeRight = false
+                    prefs.shortcutIdSwipeRight = ""
+                }
             }
 
-            Constants.FLAG_SET_HOME_APP_3 -> {
-                prefs.appName3 = appModel.appLabel
-                prefs.appPackage3 = appModel.appPackage
-                prefs.appUser3 = appModel.user.toString()
-                prefs.appActivityClassName3 = appModel.activityClassName
-                refreshHome(false)
+            is AppModel.PinnedShortcut -> {
+                if (isLeft) {
+                    prefs.appNameSwipeLeft = appModel.appLabel
+                    prefs.appPackageSwipeLeft = appModel.appPackage
+                    prefs.appUserSwipeLeft = appModel.user.toString()
+                    prefs.appActivityClassNameSwipeLeft = null
+                    prefs.isShortcutSwipeLeft = true
+                    prefs.shortcutIdSwipeLeft = appModel.shortcutId
+                } else {
+                    prefs.appNameSwipeRight = appModel.appLabel
+                    prefs.appPackageSwipeRight = appModel.appPackage
+                    prefs.appUserSwipeRight = appModel.user.toString()
+                    prefs.appActivityClassNameRight = null
+                    prefs.isShortcutSwipeRight = true
+                    prefs.shortcutIdSwipeRight = appModel.shortcutId
+                }
             }
+        }
+        updateSwipeApps()
+    }
 
-            Constants.FLAG_SET_HOME_APP_4 -> {
-                prefs.appName4 = appModel.appLabel
-                prefs.appPackage4 = appModel.appPackage
-                prefs.appUser4 = appModel.user.toString()
-                prefs.appActivityClassName4 = appModel.activityClassName
-                refreshHome(false)
-            }
+    private fun saveClockApp(appModel: AppModel) {
+        if (appModel is AppModel.App) {
+            prefs.clockAppPackage = appModel.appPackage
+            prefs.clockAppUser = appModel.user.toString()
+            prefs.clockAppClassName = appModel.activityClassName
+        }
+    }
 
-            Constants.FLAG_SET_HOME_APP_5 -> {
-                prefs.appName5 = appModel.appLabel
-                prefs.appPackage5 = appModel.appPackage
-                prefs.appUser5 = appModel.user.toString()
-                prefs.appActivityClassName5 = appModel.activityClassName
-                refreshHome(false)
-            }
-
-            Constants.FLAG_SET_HOME_APP_6 -> {
-                prefs.appName6 = appModel.appLabel
-                prefs.appPackage6 = appModel.appPackage
-                prefs.appUser6 = appModel.user.toString()
-                prefs.appActivityClassName6 = appModel.activityClassName
-                refreshHome(false)
-            }
-
-            Constants.FLAG_SET_HOME_APP_7 -> {
-                prefs.appName7 = appModel.appLabel
-                prefs.appPackage7 = appModel.appPackage
-                prefs.appUser7 = appModel.user.toString()
-                prefs.appActivityClassName7 = appModel.activityClassName
-                refreshHome(false)
-            }
-
-            Constants.FLAG_SET_HOME_APP_8 -> {
-                prefs.appName8 = appModel.appLabel
-                prefs.appPackage8 = appModel.appPackage
-                prefs.appUser8 = appModel.user.toString()
-                prefs.appActivityClassName8 = appModel.activityClassName
-                refreshHome(false)
-            }
-
-            Constants.FLAG_SET_SWIPE_LEFT_APP -> {
-                prefs.appNameSwipeLeft = appModel.appLabel
-                prefs.appPackageSwipeLeft = appModel.appPackage
-                prefs.appUserSwipeLeft = appModel.user.toString()
-                prefs.appActivityClassNameSwipeLeft = appModel.activityClassName
-                updateSwipeApps()
-            }
-
-            Constants.FLAG_SET_SWIPE_RIGHT_APP -> {
-                prefs.appNameSwipeRight = appModel.appLabel
-                prefs.appPackageSwipeRight = appModel.appPackage
-                prefs.appUserSwipeRight = appModel.user.toString()
-                prefs.appActivityClassNameRight = appModel.activityClassName
-                updateSwipeApps()
-            }
-
-            Constants.FLAG_SET_CLOCK_APP -> {
-                prefs.clockAppPackage = appModel.appPackage
-                prefs.clockAppUser = appModel.user.toString()
-                prefs.clockAppClassName = appModel.activityClassName
-            }
-
-            Constants.FLAG_SET_CALENDAR_APP -> {
-                prefs.calendarAppPackage = appModel.appPackage
-                prefs.calendarAppUser = appModel.user.toString()
-                prefs.calendarAppClassName = appModel.activityClassName
-            }
+    private fun saveCalendarApp(appModel: AppModel) {
+        if (appModel is AppModel.App) {
+            prefs.calendarAppPackage = appModel.appPackage
+            prefs.calendarAppUser = appModel.user.toString()
+            prefs.calendarAppClassName = appModel.activityClassName
         }
     }
 
@@ -204,13 +357,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun getAppList(includeHiddenApps: Boolean = false) {
         viewModelScope.launch {
-            appList.value = getAppsList(appContext, prefs, includeRegularApps = true, includeHiddenApps)
+            val apps = getAppsList(appContext, prefs, includeRegularApps = true, includeHiddenApps)
+            appList.value = apps
         }
     }
 
     fun getHiddenApps() {
         viewModelScope.launch {
-            hiddenApps.value = getAppsList(appContext, prefs, includeRegularApps = false, includeHiddenApps = true)
+            hiddenApps.value =
+                getAppsList(appContext, prefs, includeRegularApps = false, includeHiddenApps = true)
         }
     }
 
@@ -249,7 +404,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun getTodaysScreenTime() {
         if (prefs.screenTimeLastUpdated.hasBeenMinutes(1).not()) return
 
-        val eventLogWrapper = EventLogWrapper(appContext)
+        val eventLogWrapper = EventLogWrapper(
+            appContext)
         // Start of today in millis
         val calendar = Calendar.getInstance().apply {
             set(Calendar.HOUR_OF_DAY, 0)

--- a/app/src/main/java/app/olauncher/data/AppModel.kt
+++ b/app/src/main/java/app/olauncher/data/AppModel.kt
@@ -3,16 +3,33 @@ package app.olauncher.data
 import android.os.UserHandle
 import java.text.CollationKey
 
-data class AppModel(
-    val appLabel: String,
-    val key: CollationKey?,
-    val appPackage: String,
-    val activityClassName: String?,
-    val isNew: Boolean? = false,
-    val user: UserHandle,
-) : Comparable<AppModel> {
+sealed class AppModel : Comparable<AppModel> {
+    abstract val appLabel: String
+    abstract val key: CollationKey?
+    abstract val appPackage: String
+    abstract val user: UserHandle
+    abstract val isNew: Boolean
+
+    data class App(
+        override val appLabel: String,
+        override val key: CollationKey?,
+        override val appPackage: String,
+        val activityClassName: String?,
+        override val isNew: Boolean = false,
+        override val user: UserHandle,
+    ) : AppModel()
+
+    data class PinnedShortcut(
+        override val appLabel: String,
+        override val key: CollationKey?,
+        override val appPackage: String,
+        val shortcutId: String,
+        override val isNew: Boolean = false,
+        override val user: UserHandle,
+    ) : AppModel()
+
     override fun compareTo(other: AppModel): Int = when {
-        key != null && other.key != null -> key.compareTo(other.key)
+        key != null && other.key != null -> key!!.compareTo(other.key)
         else -> appLabel.compareTo(other.appLabel, true)
     }
 }

--- a/app/src/main/java/app/olauncher/data/Prefs.kt
+++ b/app/src/main/java/app/olauncher/data/Prefs.kt
@@ -91,6 +91,28 @@ class Prefs(context: Context) {
     private val CALENDAR_APP_USER = "CALENDAR_APP_USER"
     private val CALENDAR_APP_CLASS_NAME = "CALENDAR_APP_CLASS_NAME"
 
+    private val IS_SHORTCUT_1 = "IS_SHORTCUT_1"
+    private val SHORTCUT_ID_1 = "SHORTCUT_ID_1"
+    private val IS_SHORTCUT_2 = "IS_SHORTCUT_2"
+    private val SHORTCUT_ID_2 = "SHORTCUT_ID_2"
+    private val IS_SHORTCUT_3 = "IS_SHORTCUT_3"
+    private val SHORTCUT_ID_3 = "SHORTCUT_ID_3"
+    private val IS_SHORTCUT_4 = "IS_SHORTCUT_4"
+    private val SHORTCUT_ID_4 = "SHORTCUT_ID_4"
+    private val IS_SHORTCUT_5 = "IS_SHORTCUT_5"
+    private val SHORTCUT_ID_5 = "SHORTCUT_ID_5"
+    private val IS_SHORTCUT_6 = "IS_SHORTCUT_6"
+    private val SHORTCUT_ID_6 = "SHORTCUT_ID_6"
+    private val IS_SHORTCUT_7 = "IS_SHORTCUT_7"
+    private val SHORTCUT_ID_7 = "SHORTCUT_ID_7"
+    private val IS_SHORTCUT_8 = "IS_SHORTCUT_8"
+    private val SHORTCUT_ID_8 = "SHORTCUT_ID_8"
+
+    private val SHORTCUT_ID_SWIPE_LEFT = "SHORTCUT_ID_SWIPE_LEFT"
+    private val IS_SHORTCUT_SWIPE_LEFT = "IS_SHORTCUT_SWIPE_LEFT"
+    private val SHORTCUT_ID_SWIPE_RIGHT = "SHORTCUT_ID_SWIPE_RIGHT"
+    private val IS_SHORTCUT_SWIPE_RIGHT = "IS_SHORTCUT_SWIPE_RIGHT"
+
     private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_FILENAME, 0)
 
     var firstOpen: Boolean
@@ -409,6 +431,72 @@ class Prefs(context: Context) {
         get() = prefs.getString(CALENDAR_APP_CLASS_NAME, "").toString()
         set(value) = prefs.edit { putString(CALENDAR_APP_CLASS_NAME, value).apply() }
 
+    var isShortcut1: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_1, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_1, value).apply()
+    var shortcutId1: String
+        get() = prefs.getString(SHORTCUT_ID_1, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_1, value).apply()
+    var isShortcut2: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_2, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_2, value).apply()
+    var shortcutId2: String
+        get() = prefs.getString(SHORTCUT_ID_2, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_2, value).apply()
+    var isShortcut3: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_3, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_3, value).apply()
+    var shortcutId3: String
+        get() = prefs.getString(SHORTCUT_ID_3, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_3, value).apply()
+    var isShortcut4: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_4, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_4, value).apply()
+    var shortcutId4: String
+        get() = prefs.getString(SHORTCUT_ID_4, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_4, value).apply()
+    var isShortcut5: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_5, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_5, value).apply()
+    var shortcutId5: String
+        get() = prefs.getString(SHORTCUT_ID_5, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_5, value).apply()
+    var isShortcut6: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_6, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_6, value).apply()
+    var shortcutId6: String
+        get() = prefs.getString(SHORTCUT_ID_6, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_6, value).apply()
+    var isShortcut7: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_7, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_7, value).apply()
+    var shortcutId7: String
+        get() = prefs.getString(SHORTCUT_ID_7, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_7, value).apply()
+    var isShortcut8: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_8, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_8, value).apply()
+    var shortcutId8: String
+        get() = prefs.getString(SHORTCUT_ID_8, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_8, value).apply()
+
+    // Swipe left/right shortcut support
+    var shortcutIdSwipeLeft: String
+        get() = prefs.getString(SHORTCUT_ID_SWIPE_LEFT, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_SWIPE_LEFT, value).apply()
+
+    var isShortcutSwipeLeft: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_SWIPE_LEFT, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_SWIPE_LEFT, value).apply()
+
+    var shortcutIdSwipeRight: String
+        get() = prefs.getString(SHORTCUT_ID_SWIPE_RIGHT, "").toString()
+        set(value) = prefs.edit().putString(SHORTCUT_ID_SWIPE_RIGHT, value).apply()
+
+    var isShortcutSwipeRight: Boolean
+        get() = prefs.getBoolean(IS_SHORTCUT_SWIPE_RIGHT, false)
+        set(value) = prefs.edit().putBoolean(IS_SHORTCUT_SWIPE_RIGHT, value).apply()
+
     fun getAppName(location: Int): String {
         return when (location) {
             1 -> prefs.getString(APP_NAME_1, "").toString()
@@ -462,6 +550,34 @@ class Prefs(context: Context) {
             7 -> prefs.getString(APP_USER_7, "").toString()
             8 -> prefs.getString(APP_USER_8, "").toString()
             else -> ""
+        }
+    }
+
+    fun getShortcutId(location: Int): String {
+        return when (location) {
+            1 -> shortcutId1
+            2 -> shortcutId2
+            3 -> shortcutId3
+            4 -> shortcutId4
+            5 -> shortcutId5
+            6 -> shortcutId6
+            7 -> shortcutId7
+            8 -> shortcutId8
+            else -> ""
+        }
+    }
+
+    fun getIsShortcut(location: Int): Boolean {
+        return when (location) {
+            1 -> isShortcut1
+            2 -> isShortcut2
+            3 -> isShortcut3
+            4 -> isShortcut4
+            5 -> isShortcut5
+            6 -> isShortcut6
+            7 -> isShortcut7
+            8 -> isShortcut8
+            else -> false
         }
     }
 

--- a/app/src/main/java/app/olauncher/helper/PinItemActivity.kt
+++ b/app/src/main/java/app/olauncher/helper/PinItemActivity.kt
@@ -1,0 +1,51 @@
+package app.olauncher.helper
+
+import android.content.pm.LauncherApps
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class PinItemActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        // Set window to be transparent
+        window.setBackgroundDrawable(null)
+
+        val launcherApps = getSystemService(LauncherApps::class.java)
+        val pinItemRequest = launcherApps.getPinItemRequest(intent)
+
+        when (pinItemRequest != null) {
+            true -> handleRequestType(pinItemRequest)
+            false -> showToast("Invalid pin request")
+        }
+
+        finish()
+    }
+
+    private fun handleRequestType(pinItemRequest: LauncherApps.PinItemRequest) {
+        when (pinItemRequest.requestType) {
+            LauncherApps.PinItemRequest.REQUEST_TYPE_SHORTCUT ->
+                handleShortcutRequest(pinItemRequest)
+
+            LauncherApps.PinItemRequest.REQUEST_TYPE_APPWIDGET ->
+                showToast("Widgets are not supported")
+
+            else -> showToast("Unknown action not supported")
+        }
+    }
+
+    private fun handleShortcutRequest(pinItemRequest: LauncherApps.PinItemRequest) {
+        val shortcutInfo = pinItemRequest.shortcutInfo
+        if (shortcutInfo != null) {
+            val success = pinItemRequest.accept()
+            val message = when (success) {
+                true -> "Shortcut pinned successfully"
+                false -> "Failed to pin shortcut"
+            }
+            showToast(message)
+        } else {
+            showToast("Invalid shortcut info")
+        }
+    }
+}


### PR DESCRIPTION
Issue: #20

### Summary

  - Add pinned shortcut support
  - This makes it possible to have:
    -  Progressive Web Apps (PWA)
    -  Browser link shortcuts as part of the launcher besides apps
    - Whatsapp shortcuts
    - etc.

### Changes

  - Introduce PinItemActivity to accept pin shortcut requests from the system.
  - Extend AppModel and app list loading to include pinned shortcuts alongside apps.
  - Persist pinned shortcuts for home slots and swipe actions, and launch/delete them appropriately.
  - Update app drawer UI behaviors (diffing, rename, delete, hide) to handle shortcut entries.

#### Other thoughts, but kept out of scope:

  - Migrate to DataStore instead of SharedPreferences
  - Instead of hardcoded numbering from 1 to 8 for each property, have it as a scalable list - now the shortcuts are also having hardcoded 1 until 8 properties.

### Demo


https://github.com/user-attachments/assets/22ed5492-9d87-4a61-a1a5-934459f76348

