### PR TITLE
Fix fatal crash when renaming apps outside the 'main' user profile

### DIFF
--- a/app/src/main/java/app/olauncher/helper/Utils.kt
+++ b/app/src/main/java/app/olauncher/helper/Utils.kt
@@ -500,12 +500,21 @@ fun Context.openUrl(url: String) {
     startActivity(intent)
 }
 
-fun Context.isSystemApp(packageName: String): Boolean {
+fun Context.isSystemApp(packageName: String, user: UserHandle? = null): Boolean {
     if (packageName.isBlank()) return true
     return try {
-        val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
-        ((applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0)
-                || (applicationInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0))
+        val launcherApps = getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        val targetUser = user ?: android.os.Process.myUserHandle()
+        val activityList = launcherApps.getActivityList(packageName, targetUser)
+        if (activityList.isNotEmpty()) {
+            val applicationInfo = activityList.first().applicationInfo
+            ((applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0)
+                    || (applicationInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0))
+        } else {
+            val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
+            ((applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0)
+                    || (applicationInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0))
+        }
     } catch (e: Exception) {
         e.printStackTrace()
         false

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -140,7 +140,7 @@ class AppDrawerFragment : Fragment() {
 
                     is AppModel.App -> {
                         requireContext().apply {
-                            if (isSystemApp(appModel.appPackage))
+                            if (isSystemApp(appModel.appPackage, appModel.user))
                                 showToast(getString(R.string.system_app_cannot_delete))
                             else
                                 uninstall(appModel.appPackage)


### PR DESCRIPTION
When renaming an app outside the 'main' or current user profile, Olauncher would crash with this error (or a variation upon it):

```
FATAL EXCEPTION: main
Process: app.olauncher, PID: 15015
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:603)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:940)
Caused by: java.lang.reflect.InvocationTargetException
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
... 1 more
Caused by: android.content.pm.PackageManager$NameNotFoundException: com.Slack
at android.app.ApplicationPackageManager.getApplicationInfoAsUser(ApplicationPackageManager.java:737)
at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:698)
at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:692)
at S0.f.afterTextChanged(SourceFile:30)
at android.widget.TextView.sendAfterTextChanged(TextView.java:13094)
at android.widget.TextView.setText(TextView.java:7590)
at android.widget.TextView.setText(TextView.java:7388)
at android.widget.EditText.setText(EditText.java:184)
at android.widget.TextView.setText(TextView.java:7326)
at S0.b.onClick(SourceFile:162)
at android.view.View.performClick(View.java:8137)
at android.view.View.performClickInternal(View.java:8114)
at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
at android.view.View$PerformClick.run(View.java:32088)
at android.os.Handler.handleCallback(Handler.java:995)
at android.os.Handler.dispatchMessage(Handler.java:103)
at android.os.Looper.loopOnce(Looper.java:282)
at android.os.Looper.loop(Looper.java:397)
at android.app.ActivityThread.main(ActivityThread.java:10236)
... 3 more
```

This was caused by renaming an app that was exclusively installed within my work profile.

The fix uses the `LauncherApps.getActivityList` function that can get app information from whatever user profile the app is installed to.

The existing `packageManager.getApplicationInfo` is still used as a fallback. If all fails, an empty string is displayed to prevent a crash.

Fixes https://github.com/tanujnotes/Olauncher/issues/600

---

Full disclosure: I am not very knowledgeable in native Android app development so this code was written with the help of AI within Android Studio. I did test the changes both on an emulated Pixel 9a and my own phone. It prevented the above crash and allowed me to rename the work apps.