### PR TITLE
Fix PWA shortcut refresh and identity collisions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,4 +64,5 @@ dependencies {
     //Material dependency
     implementation libs.material
 
+    testImplementation libs.junit
 }

--- a/app/src/main/java/app/olauncher/MainActivity.kt
+++ b/app/src/main/java/app/olauncher/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
+import android.content.pm.LauncherApps
+import android.content.pm.ShortcutInfo
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
@@ -54,6 +56,7 @@ class MainActivity : AppCompatActivity() {
     private var timerJob: Job? = null
     private var isResumed = false
     private var profileReceiver: BroadcastReceiver? = null
+    private var launcherAppsCallback: LauncherApps.Callback? = null
 
 //    override fun onBackPressed() {
 //        if (navController.currentDestination?.id != R.id.mainFragment)
@@ -105,6 +108,7 @@ class MainActivity : AppCompatActivity() {
         initClickListeners()
         initObservers(viewModel)
         viewModel.getAppList()
+        registerShortcutCallback()
         setupOrientation()
 
         window.addFlags(FLAG_LAYOUT_NO_LIMITS)
@@ -133,6 +137,36 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         isResumed = true
         viewModel.isPrivateSpaceToggling = false
+        viewModel.getAppList()
+    }
+
+    private fun registerShortcutCallback() {
+        val launcherApps = getSystemService(LauncherApps::class.java)
+        launcherAppsCallback = object : LauncherApps.Callback() {
+            override fun onPackageRemoved(packageName: String, user: android.os.UserHandle) = Unit
+            override fun onPackageAdded(packageName: String, user: android.os.UserHandle) = Unit
+            override fun onPackageChanged(packageName: String, user: android.os.UserHandle) = Unit
+            override fun onPackagesAvailable(
+                packageNames: Array<out String>,
+                user: android.os.UserHandle,
+                replacing: Boolean,
+            ) = Unit
+
+            override fun onPackagesUnavailable(
+                packageNames: Array<out String>,
+                user: android.os.UserHandle,
+                replacing: Boolean,
+            ) = Unit
+
+            override fun onShortcutsChanged(
+                packageName: String,
+                shortcuts: MutableList<ShortcutInfo>,
+                user: android.os.UserHandle,
+            ) {
+                viewModel.getAppList()
+            }
+        }
+        launcherApps.registerCallback(launcherAppsCallback!!)
     }
 
     override fun onStop() {
@@ -367,6 +401,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        launcherAppsCallback?.let {
+            getSystemService(LauncherApps::class.java).unregisterCallback(it)
+        }
         profileReceiver?.let {
             try {
                 unregisterReceiver(it)

--- a/app/src/main/java/app/olauncher/MainViewModel.kt
+++ b/app/src/main/java/app/olauncher/MainViewModel.kt
@@ -104,12 +104,20 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private fun launchShortcut(appModel: AppModel.PinnedShortcut) {
         val launcher = appContext.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
         val query = LauncherApps.ShortcutQuery().apply {
+            setPackage(appModel.appPackage)
             setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED)
         }
-        launcher.getShortcuts(query, appModel.user)?.find { it.id == appModel.shortcutId }
-            ?.let { shortcut ->
-                launcher.startShortcut(shortcut, null, null)
+        try {
+            val shortcut = launcher.getShortcuts(query, appModel.user)
+                ?.find { it.id == appModel.shortcutId }
+            if (shortcut == null) {
+                appContext.showToast(appContext.getString(R.string.shortcut_not_found))
+                return
             }
+            launcher.startShortcut(shortcut, null, null)
+        } catch (_: Exception) {
+            appContext.showToast(appContext.getString(R.string.unable_to_open_shortcut))
+        }
     }
 
     private fun saveHomeApp(appModel: AppModel, position: Int) {

--- a/app/src/main/java/app/olauncher/data/AppModel.kt
+++ b/app/src/main/java/app/olauncher/data/AppModel.kt
@@ -26,7 +26,10 @@ sealed class AppModel : Comparable<AppModel> {
         val shortcutId: String,
         override val isNew: Boolean = false,
         override val user: UserHandle,
-    ) : AppModel()
+    ) : AppModel() {
+        val identity: String
+            get() = shortcutIdentity(appPackage, shortcutId, user.toString())
+    }
 
     data class PrivateSpaceHeader(
         val isLocked: Boolean = true,

--- a/app/src/main/java/app/olauncher/data/ShortcutIdentity.kt
+++ b/app/src/main/java/app/olauncher/data/ShortcutIdentity.kt
@@ -1,0 +1,4 @@
+package app.olauncher.data
+
+fun shortcutIdentity(packageName: String, shortcutId: String, user: String): String =
+    "shortcut:${packageName.length}:$packageName${shortcutId.length}:$shortcutId${user.length}:$user"

--- a/app/src/main/java/app/olauncher/helper/PinItemActivity.kt
+++ b/app/src/main/java/app/olauncher/helper/PinItemActivity.kt
@@ -3,13 +3,13 @@ package app.olauncher.helper
 import android.content.pm.LauncherApps
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import app.olauncher.R
 
 class PinItemActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         
-        // Set window to be transparent
         window.setBackgroundDrawable(null)
 
         val launcherApps = getSystemService(LauncherApps::class.java)
@@ -17,7 +17,7 @@ class PinItemActivity : AppCompatActivity() {
 
         when (pinItemRequest != null) {
             true -> handleRequestType(pinItemRequest)
-            false -> showToast("Invalid pin request")
+            false -> showToast(R.string.invalid_pin_request)
         }
 
         finish()
@@ -29,23 +29,23 @@ class PinItemActivity : AppCompatActivity() {
                 handleShortcutRequest(pinItemRequest)
 
             LauncherApps.PinItemRequest.REQUEST_TYPE_APPWIDGET ->
-                showToast("Widgets are not supported")
+                showToast(R.string.widgets_not_supported)
 
-            else -> showToast("Unknown action not supported")
+            else -> showToast(R.string.pin_action_not_supported)
         }
     }
 
     private fun handleShortcutRequest(pinItemRequest: LauncherApps.PinItemRequest) {
         val shortcutInfo = pinItemRequest.shortcutInfo
         if (shortcutInfo != null) {
-            val success = pinItemRequest.accept()
+            val success = runCatching { pinItemRequest.accept() }.getOrDefault(false)
             val message = when (success) {
-                true -> "Shortcut pinned successfully"
-                false -> "Failed to pin shortcut"
+                true -> R.string.shortcut_pinned
+                false -> R.string.shortcut_pin_failed
             }
             showToast(message)
         } else {
-            showToast("Invalid shortcut info")
+            showToast(R.string.invalid_shortcut)
         }
     }
 }

--- a/app/src/main/java/app/olauncher/helper/Utils.kt
+++ b/app/src/main/java/app/olauncher/helper/Utils.kt
@@ -43,6 +43,7 @@ import app.olauncher.R
 import app.olauncher.data.AppModel
 import app.olauncher.data.Constants
 import app.olauncher.data.Prefs
+import app.olauncher.data.shortcutIdentity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -150,8 +151,14 @@ private suspend fun getPinnedShortcuts(
                 if (isPrivateSpaceProfile(context, profile)) return@forEach
                 try {
                     shortcuts.getShortcuts(query, profile)?.forEach { shortcut ->
-                        if (shortcut.isPinned && pinnedShortcuts.none { it.shortcutId == shortcut.id }) {
-                            val label = prefs.getAppRenameLabel(shortcut.id)
+                        val identity = shortcutIdentity(
+                            shortcut.`package`,
+                            shortcut.id,
+                            profile.toString()
+                        )
+                        if (shortcut.isPinned && pinnedShortcuts.none { it.identity == identity }) {
+                            val label = prefs.getAppRenameLabel(identity)
+                                .ifBlank { prefs.getAppRenameLabel(shortcut.id) }
                                 .takeIf { it.isNotBlank() }
                                 ?: shortcut.shortLabel?.toString()
                                 ?: shortcut.longLabel?.toString().orEmpty()

--- a/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerAdapter.kt
@@ -47,7 +47,7 @@ class AppDrawerAdapter(
                     oldItem.appPackage == newItem.appPackage && oldItem.user == newItem.user
 
                 oldItem is AppModel.PinnedShortcut && newItem is AppModel.PinnedShortcut ->
-                    oldItem.shortcutId == newItem.shortcutId && oldItem.user == newItem.user
+                    oldItem.identity == newItem.identity
 
                 oldItem is AppModel.PrivateSpaceHeader && newItem is AppModel.PrivateSpaceHeader -> true
 

--- a/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/AppDrawerFragment.kt
@@ -220,7 +220,7 @@ class AppDrawerFragment : BaseFragment() {
             },
             appRenameListener = { appModel, renameLabel ->
                 val identifier = when (appModel) {
-                    is AppModel.PinnedShortcut -> appModel.shortcutId
+                    is AppModel.PinnedShortcut -> appModel.identity
                     is AppModel.App -> appModel.appPackage
                     else -> return@AppDrawerAdapter
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,4 +167,12 @@
     <string name="cheers">Cheers!</string>
     <string name="notification_bar">Notification bar</string>
     <string name="private_space">Private space</string>
+    <string name="invalid_pin_request">Invalid pin request</string>
+    <string name="widgets_not_supported">Widgets are not supported</string>
+    <string name="pin_action_not_supported">This pin action is not supported</string>
+    <string name="shortcut_pinned">Shortcut added</string>
+    <string name="shortcut_pin_failed">Could not add shortcut</string>
+    <string name="invalid_shortcut">Invalid shortcut</string>
+    <string name="shortcut_not_found">Shortcut not found</string>
+    <string name="unable_to_open_shortcut">Unable to open shortcut</string>
 </resources>

--- a/app/src/test/java/app/olauncher/data/ShortcutIdentityTest.kt
+++ b/app/src/test/java/app/olauncher/data/ShortcutIdentityTest.kt
@@ -1,0 +1,31 @@
+package app.olauncher.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ShortcutIdentityTest {
+    @Test
+    fun `identity is stable`() {
+        assertEquals(
+            shortcutIdentity("org.browser", "https://example.com", "UserHandle{0}"),
+            shortcutIdentity("org.browser", "https://example.com", "UserHandle{0}"),
+        )
+    }
+
+    @Test
+    fun `same shortcut id from different browsers has different identity`() {
+        assertNotEquals(
+            shortcutIdentity("org.browser.one", "https://example.com", "UserHandle{0}"),
+            shortcutIdentity("org.browser.two", "https://example.com", "UserHandle{0}"),
+        )
+    }
+
+    @Test
+    fun `field boundaries cannot collide`() {
+        assertNotEquals(
+            shortcutIdentity("ab", "c", "d"),
+            shortcutIdentity("a", "bc", "d"),
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ material = "1.12.0"
 navigationFragmentKtx = "2.9.0"
 recyclerview = "1.4.0"
 workRuntimeKtx = "2.10.1"
+junit = "4.13.2"
 [libraries]
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -21,3 +22,4 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
+junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
PWA shortcuts now appear in the app drawer as soon as a browser pins them.

This also fixes shortcut ID collisions. Android only guarantees that an ID is unique within its publishing app, so shortcut lookup and rename storage now include the browser package and user profile.

Pin and launch failures now show an error instead of failing silently.

Tested with:

- `./gradlew testDebugUnitTest assembleDebug`
- Firefox on a Pixel 8a
- MDN's A2HS demo PWA

The `Foxes` shortcut appeared in Olauncher and launched successfully. The Android crash log remained empty.