### PR TITLE
Skip screen time calculation when disabled

### DIFF
--- a/app/src/main/java/app/olauncher/MainViewModel.kt
+++ b/app/src/main/java/app/olauncher/MainViewModel.kt
@@ -22,6 +22,7 @@ import app.olauncher.data.Constants
 import app.olauncher.data.Prefs
 import app.olauncher.helper.SingleLiveEvent
 import app.olauncher.helper.WallpaperWorker
+import app.olauncher.helper.appUsagePermissionGranted
 import app.olauncher.helper.formattedTimeSpent
 import app.olauncher.helper.getAppsList
 import app.olauncher.helper.getPrivateSpaceApps
@@ -434,6 +435,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun getTodaysScreenTime() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q
+            || appContext.appUsagePermissionGranted().not()
+        ) return
         if (prefs.screenTimeLastUpdated.hasBeenMinutes(1).not()) return
 
         val eventLogWrapper = EventLogWrapper(

--- a/app/src/main/java/app/olauncher/ui/HomeFragment.kt
+++ b/app/src/main/java/app/olauncher/ui/HomeFragment.kt
@@ -289,7 +289,10 @@ class HomeFragment : BaseFragment(), View.OnClickListener, View.OnLongClickListe
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun populateScreenTime() {
-        if (requireContext().appUsagePermissionGranted().not()) return
+        if (requireContext().appUsagePermissionGranted().not()) {
+            binding.tvScreenTime.visibility = View.GONE
+            return
+        }
 
         viewModel.getTodaysScreenTime()
         binding.tvScreenTime.visibility = View.VISIBLE


### PR DESCRIPTION
## Summary

- skip screen-time usage-event processing when Usage Access is disabled
- hide stale screen-time text after the permission is revoked
- retain the existing one-minute refresh behavior when the feature is enabled

## Why

Screen time is optional, but the ViewModel calculation did not enforce that boundary itself. Keeping the guard next to the expensive usage-event query prevents accidental processing when the feature is disabled, while the UI guard ensures a previously rendered value is removed.

## Impact

Users who have disabled screen time no longer enter its calculation path. Behavior is unchanged for users who have enabled the feature.

## Validation

- `ANDROID_HOME=/Users/damullan/Library/Android/sdk ./gradlew compileDebugKotlin`
- Build completed successfully
